### PR TITLE
Add Chinese translation for Ethereum clients chapter

### DIFF
--- a/01what-is.zh.asciidoc
+++ b/01what-is.zh.asciidoc
@@ -1,0 +1,247 @@
+[role="pagenumrestart"]
+[[whatis_chapter]]
+== 什么是以太坊？
+
+((("Ethereum (generally)","about", id="ix_01what-is-asciidoc0", range="startofrange")))以太坊((("world computer, Ethereum as")))常被描述为“世界计算机”。但这究竟意味着什么？让我们先从计算机科学的角度给出一个定义，再通过更实际的分析来解读以太坊的能力和特性，并与比特币以及其他去中心化信息交换平台（简称“区块链”）进行比较。
+
+从计算机科学的角度看，以太坊是一个确定性的、在实践中几乎没有边界的状态机，由一个全球可访问的单例状态和一个负责对该状态施加变更的虚拟机组成。
+
+从更实际的角度看，以太坊是一套开源、全球去中心化的计算基础设施，用于执行称为_智能合约_的程序。它使用区块链同步并存储系统的状态变更，同时通过一种名为_以太_的加密货币对执行所需的资源进行计量和约束。
+
+以太坊平台使开发者能够构建具有内置经济功能的强大去中心化应用。它在提供高可用性、可审计性、透明性和中立性的同时，也降低或消除了审查，并减少了某些对手风险。
+
+[[bitcoin_comparison]]
+=== 与比特币的比较
+
+((("Bitcoin","Ethereum compared to")))((("Ethereum (generally)","Bitcoin compared to")))许多人在接触以太坊之前已经对加密货币有所了解，特别是比特币。以太坊与其他开放区块链有许多共同要素：一个连接参与者的点对点网络、一种用于同步状态更新的拜占庭容错共识算法（即工作量证明区块链）、用于数字签名和哈希的密码学原语，以及一种数字货币（以太）。
+
+然而，无论从目的还是结构来看，以太坊与之前的开放区块链（包括比特币）都有着显著的不同。
+
+((("Ethereum (generally)","purpose of")))以太坊的主要目的并不是打造一个数字货币支付网络。((("utility currency, ether as")))虽然以太这种数字货币对以太坊的运行不可或缺，但以太被设计为一种_功能性货币_，用于支付在世界计算机——以太坊平台——上的使用费用。
+
+与脚本语言非常有限的比特币不同，以太坊被设计成一条通用的可编程区块链，它运行一个能够执行任意复杂度代码的_虚拟机_。比特币的 Script 语言被刻意限制在对支出条件进行简单真/假评估，而以太坊的语言则是_图灵完备_的，也就是说，以太坊能够轻松地充当一台通用计算机。
+
+[[blockchain_components]]
+=== 区块链的组成部分
+
+((("blockchain","components of")))((("Ethereum (generally)","blockchain components")))一个开放、公共区块链的组成部分通常包括：
+
+* 一个连接参与者并传播交易及经过验证的交易区块的点对点（P2P）网络，基于标准化的“八卦” pass:[<span class="keep-together">协议</span>]
+* 表示状态转换的消息（交易）
+* 一组共识规则，用于界定什么构成交易以及什么是有效的状态转换
+* 根据共识规则处理交易的状态机
+* 一条由加密方式保护的区块链，作为所有已验证且被接受的状态转换的日志
+* 一个共识算法，通过迫使参与者协同执行共识规则来去中心化区块链的控制权
+* 一个在开放 pass:[<span class="keep-together">环境</span>]中基于博弈论的激励机制（例如工作量证明的成本加区块奖励），用于在经济层面上保护状态机
+* 一个或多个上述组件的开源软件实现（“客户端”）
+
+通常，这些组件会组合在一个软件客户端中。例如，在比特币中，((("Bitcoin Core")))((("bitcoind client")))由 _Bitcoin Core_ 开源项目开发的参考实现以 _bitcoind_ 客户端的形式发布。而在以太坊中，没有参考实现，取而代之的是((("reference specification")))一份_参考规范_——黄皮书中的系统数学描述（参见<<references>>）。有许多客户端都是依据参考规范构建的。
+
+过去，我们常用“区块链”这一术语来指代刚刚列出的所有组件，以简化地代表涵盖所有这些特性的技术组合。然而今天，具有不同属性的区块链种类繁多。我们需要使用限定词（例如_开放、公共、全球、去中心化、中立_和_抗审查_）来帮助我们理解特定区块链所具备的特性，以识别这些组件组合所带来的重要涌现特征。
+
+并非所有区块链都是一样的。当有人告诉你某样东西是区块链时，你并没有得到答案；相反，你需要提出更多问题来澄清他们在使用“区块链”一词时的含义。先要求对前面列表中的组件进行说明，然后再询问该“区块链”是否具备_开放、公共_等特性。
+
+[[ethereum_birth]]
+=== 以太坊的诞生
+
+((("Ethereum (generally)","birth of")))所有伟大的创新都在解决现实问题，以太坊也不例外。以太坊诞生于人们意识到比特币模型的力量，并试图走出纯粹的加密货币应用之时。但开发者面临一个难题：他们要么在比特币之上构建，要么启动一条新的区块链。((("Bitcoin","limitations of")))如果构建在比特币之上，就必须在该网络有意设置的约束内寻找变通办法。有限的交易类型、数据类型以及数据存储大小，使得能够直接在比特币上运行的应用受到限制；其他所有情况都需要额外的链下层，这立即抵消了使用公共区块链的许多优势。对于那些希望保持链上部署同时又需要更大自由度和灵活性的项目来说，唯一的选择就是创建新的区块链。但这意味着大量工作：从启动所有基础设施，到进行全面测试，等等。
+
+((("Buterin, Vitalik","and birth of Ethereum")))2013 年末，年轻的程序员兼比特币爱好者 Vitalik Buterin 开始思考如何进一步扩展比特币和 Mastercoin（一个扩展比特币以提供基础智能合约的覆盖协议）的能力。同年 10 月，Vitalik 向 Mastercoin 团队提出了一个更通用的方案，使可灵活编写脚本（但非图灵完备）的合约可以取代 Mastercoin 的专用合约语言。尽管 Mastercoin 团队对此印象深刻，但该提案变动过大，无法纳入他们的开发路线图。
+
+2013 年 12 月，Vitalik 开始分享阐述以太坊理念的白皮书：一条图灵完备的通用区块链。几十人看到了这一早期草稿并提供反馈，帮助 Vitalik 不断完善提案。
+
+本书两位作者都收到了白皮书的早期草稿并进行了评论。Andreas M. Antonopoulos 对这个想法很感兴趣，向 Vitalik 提出了许多问题，涉及使用一条独立区块链来在智能合约执行上执行共识规则以及图灵完备语言的含义。Andreas 持续以极大的兴趣关注以太坊的进展，但当时正处于撰写 _Mastering Bitcoin_ 的早期阶段，因此直到更晚才直接参与以太坊。((("Wood, Dr. Gavin","and birth of Ethereum")))然而，Dr. Gavin Wood 是最早联系 Vitalik 并以其 C++ 编程技能提供帮助的人之一。Gavin 成为以太坊的联合创始人、共同设计者和首席技术官。
+
+正如 Vitalik 在他的 http://bit.ly/2T2t6zs[《Ethereum Prehistory》文章]中回忆的那样：
+
+____
+那段时间，以太坊协议完全由我独自构想。从那时起，新参与者开始加入其中。在协议方面，最引人瞩目的莫过于 Gavin Wood……
+
+Gavin 在愿景转变中也功不可没：从将以太坊视为构建可编程货币的平台——通过基于区块链的合约持有数字资产并按照预设规则转移——逐渐转向将其视为一个通用计算平台。这一转变始于措辞和强调的细微变化，后来随着对“Web 3”生态日益重视而愈发明显。在这套分布式技术组合中，以太坊只是其中一环，另外两环是 Whisper 和 Swarm。
+____
+
+自 2013 年 12 月起，Vitalik 和 Gavin 共同打磨并发展这一理念，一起构建出后来成为以太坊的协议层。
+
+以太坊的创始人们设想了一条没有特定用途的区块链，通过_编程_就能支持各种应用。这个想法是：开发者使用像以太坊这样的通用区块链，就可以编写自己的应用程序，而无需为了每一个新项目都创建一条新链。
+
+[[development_stages]]
+=== 以太坊的四个发展阶段
+
+((("Ethereum (generally)","four stages of development")))以太坊的开发被规划为四个截然不同的阶段，每个阶段都会发生重大变化。((("hard forks", seealso="DAO; other specific hard forks, e.g.: Spurious Dragon")))一个阶段可能包括若干子版本，即“硬分叉”，这些更新会以不向后兼容的方式改变功能。
+
+四个主要的发展阶段分别被命名为 _Frontier_、_Homestead_、_Metropolis_ 和 _Serenity_。到目前为止出现的中间硬分叉包括 _Ice Age_、_DAO_、_Tangerine Whistle_、_Spurious Dragon_、_Byzantium_、_Constantinople/St. Petersburg_、_Istanbul_ 和 _Muir Glacier_。发展阶段和中间硬分叉都显示在下方时间线上，该时间线以区块高度标注：
+
+Block #0:: ((("Frontier")))__Frontier__——以太坊的初始阶段，从 2015 年 7 月 30 日持续到 2016 年 3 月。
+
+Block #200,000:: ((("Ice Age")))__Ice Age__——一个硬分叉，引入难度指数级增长，以在条件成熟时推动向 PoS 过渡。
+
+Block #1,150,000:: ((("Homestead")))__Homestead__——以太坊的第二阶段，于 2016 年 3 月启动。
+
+Block #1,192,000:: ((("DAO (Decentralized Autonomous Organization)")))__DAO__——一个硬分叉，用于补偿遭黑客攻击的 DAO 合约受害者，并导致以太坊与以太坊经典分裂成两个竞争体系。
+
+Block #2,463,000:: ((("Tangerine Whistle")))__Tangerine Whistle__——一个硬分叉，用以调整某些 I/O 密集型操作的 gas 计算，并清理利用这些操作低成本而发动的拒绝服务攻击累积的状态。
+
+Block #2,675,000:: ((("Spurious Dragon")))__Spurious Dragon__——一个硬分叉，用于解决更多拒绝服务攻击向量，并再次清理状态，同时加入重放攻击防护机制。
+
+Block #4,370,000:: ((("Metropolis")))((("Byzantium fork")))__Metropolis Byzantium__——Metropolis 是以太坊的第三阶段。Byzantium 于 2017 年 10 月推出，是 Metropolis 的第一部分，增加了底层功能并调整区块奖励和难度。
+
+Block #7,280,000:: ((("Constantinople fork")))((("St. Petersburg fork")))__Constantinople / St. Petersburg__——Constantinople 原计划作为 Metropolis 的第二部分，带来类似改进。在激活前数小时，人们发现了一个 https://bit.ly/2Ast7rz[关键漏洞]。因此硬分叉被推迟并改名为 St. Petersburg。
+
+Block #9,069,000:: ((("Istanbul fork")))__Istanbul__——又一次硬分叉，其方法和命名惯例与前两次相同。
+
+Block #9,200,000:: ((("Muir Glacier fork")))__Muir Glacier__——一个硬分叉，其唯一目的就是再次调整难度，以应对 Ice Age 引入的指数级增长。
+
+((("Serenity")))((("Ethereum 2.0")))此外，还宣布了 Berlin 和 London 两次硬分叉，我们如今正处于以 Serenity 为代号的以太坊开发最后阶段。Serenity 涉及对基础设施的深度重构，使以太坊更具扩展性、更安全且更可持续。它被呈现为以太坊的第二个版本——“以太坊 2.0”。
+
+[[general_purpose_blockchain]]
+=== 以太坊：一条通用区块链
+
+((("Bitcoin","Ethereum blockchain compared to Bitcoin blockchain")))((("Ethereum (generally)","as general-purpose blockchain")))最早的区块链，即比特币区块链，用于追踪比特币单位及其所有权的状态。((("distributed state machine, Ethereum as")))我们可以将比特币视为一个分布式共识_状态机_，其中交易引发全球性的_状态转换_，从而改变币的所有权。状态转换受共识规则约束，使所有参与者在若干区块挖出后（最终）收敛至系统的公共（共识）状态。
+
+以太坊同样是一个分布式状态机。但它追踪的并不仅是货币所有权状态的变化，((("key-value tuple")))而是一个通用数据存储的状态转换，即可以保存任何以_键值对_表示的数据。键值存储保存任意值，并由某个键引用；例如，键“书名”对应的值可以是《精通以太坊》。在某种意义上，这与大多数通用计算机使用的_随机存取存储器_（RAM）的数据存储模型具有相同作用。以太坊拥有同时存储代码和数据的内存，并使用以太坊区块链来记录这块内存随时间变化的情况。像通用的存储程序计算机一样，以太坊可以将代码载入其状态机并_运行_这些代码，将由此产生的状态变化存储在区块链中。与大多数通用计算机相比，两个关键差异在于：以太坊的状态变化受共识规则约束，且状态在全球范围内分布式维护。以太坊回答了这样的问题：“如果我们能够追踪任意状态，并对状态机编程，让它在共识之下运行一台全球计算机，会怎样？”
+
+[[ethereum_components]]
+=== 以太坊的组成
+
+((("blockchain","components of")))((("Ethereum (generally)","blockchain components")))在以太坊中，<<blockchain_components>> 所述的区块链系统组件更具体地表现为：
+
+P2P 网络:: 以太坊运行在_以太坊主网_之上，可通过 TCP 端口 30303 访问，并运行一种名为 _ÐΞVp2p_ 的协议。
+
+共识规则:: 以太坊的共识规则定义在参考规范——黄皮书中（参见<<references>>）。
+
+交易:: 以太坊交易是网络消息，其中包含（除其他内容外）发送方、接收方、金额以及数据负载。
+
+[role="pagebreak-before"]
+状态机:: 以太坊的状态转换由_以太坊虚拟机_（EVM）处理。EVM 是一个基于栈的虚拟机，用于执行_字节码_（机器语言指令）。EVM 程序被称为“智能合约”，它们使用高级语言（例如 Solidity）编写，并编译为字节码在 EVM 上执行。
+
+数据结构:: 以太坊的状态在每个节点上本地存储为一个_数据库_（通常是 Google 的 LevelDB），其中包含交易和系统状态，这些数据以一种称为_默克尔帕特里夏树_的序列化哈希数据结构存储。
+
+共识算法:: 以太坊采用比特币的共识模型——中本聪共识。该模型通过串行的单签名区块，并使用工作量证明（PoW）按重要性加权，来确定最长链，从而确定当前状态。不过，未来计划迁移到一种基于权益证明（PoS）的加权投票系统，代号为 _Casper_。
+
+经济安全性:: 以太坊目前使用一种称为 _Ethash_ 的 PoW 算法，但随着未来某个时间点迁移到 PoS，该算法最终会被淘汰。
+
+客户端:: 以太坊拥有多个互操作的客户端实现，其中最知名的是 _Go-Ethereum_（_Geth_）和 _Parity_。
+
+[[references]]
+==== 延伸阅读
+
+以下参考资料提供了关于这里提到技术的更多信息：
+
+* 以太坊黄皮书：
+https://ethereum.github.io/yellowpaper/paper.pdf
+
+* 《Beige Paper》，以更通俗的语言重写黄皮书，面向更广泛的读者：
+https://github.com/chronaeon/beigepaper
+
+* ÐΞVp2p 网络协议：
+https://github.com/ethereum/devp2p/blob/master/rlpx.md
+
+* 以太坊虚拟机资源列表：
+https://eth.wiki/en/concepts/evm/ethereum-virtual-machine-(evm)-awesome-list
+
+* LevelDB 数据库（最常用于存储区块链的本地副本）：
+https://github.com/google/leveldb
+
+* 默克尔帕特里夏树：
+https://eth.wiki/en/fundamentals/patricia-tree
+
+* Ethash 工作量证明算法：
+https://eth.wiki/en/concepts/ethash/ethash
+
+* Casper PoS v1 实现指南：
+http://bit.ly/2DyPr3l
+
+* Go-Ethereum（Geth）客户端：
+https://geth.ethereum.org/
+
+* Parity 以太坊客户端：
+https://parity.io/
+
+[[turing_completeness]]
+=== 以太坊与图灵完备性
+
+((("Ethereum (generally)","Turing completeness and")))((("Turing completeness","Ethereum and")))一旦你开始阅读有关以太坊的资料，就会马上遇到“图灵完备”这一术语。人们说，以太坊与比特币不同，是图灵完备的。这究竟意味着什么？
+
+((("Turing, Alan")))这个术语来自英国数学家艾伦·图灵，他被视为计算机科学之父。1936 年，他创建了一个计算机的数学模型，即一个通过读取和写入顺序内存（类似无限长的纸带）上的符号来操作的状态机。借助这一构造，图灵为回答_普遍可计算性_问题（即所有问题是否都可被求解）提供了数学基础，并给出了否定的答案。他证明存在一些不可计算的问题。((("halting problem")))具体来说，他证明了_停机问题_（给定任意程序及其输入，能否判断该程序最终会停止运行）是不可解的。
+
+((("Universal Turing machine (UTM)")))((("UTM (Universal Turing machine)")))图灵进一步定义：如果一个系统能够模拟任何图灵机，那么它就是_图灵完备_的。这样的系统被称为_通用图灵机_（UTM）。
+
+以太坊能够在称为以太坊虚拟机的状态机中执行存储程序，同时从内存中读取和写入数据，因此它是一个图灵完备系统，也就是一台 UTM。在有限内存的约束下，以太坊可以计算任何由其他图灵机可计算的算法。
+
+以太坊的突破性创新在于，将存储程序计算机的通用计算架构与去中心化区块链结合起来，从而打造出一个分布式的单一状态（单例）世界计算机。以太坊程序在“各处”运行，却在共识规则的保护下产生统一的状态。
+
+[[turing_completeness_feature]]
+==== 将图灵完备视为“特性”
+
+((("Turing completeness","as feature")))听说以太坊是图灵完备的，你可能会得出这样的结论：图灵不完备的系统缺少了某种_特性_。事实恰好相反。实现图灵完备其实非常容易；事实上，http://bit.ly/2ABft33[已知最简单的图灵完备状态机]只有 4 个状态、使用 6 个符号，其状态定义仅有 22 条指令。实际上，系统有时会被发现“意外地图灵完备”。有关此类系统的趣味参考可在 http://bit.ly/2Og1VgX[] 找到。
+
+然而，在像公共区块链这样的开放访问系统中，图灵完备性非常危险，这正与我们前面提到的停机问题有关。例如，现代打印机是图灵完备的，可以被提供某些打印文件而陷入死机状态。以太坊是图灵完备的意味着任何复杂度的程序都可以由以太坊计算。但这种灵活性也带来了棘手的安全和资源管理问题。一台失去响应的打印机可以重启，但公共区块链无法那样操作。
+
+[[turing_completeness_implications]]
+==== 图灵完备性的影响
+
+((("Turing completeness","implications of")))图灵证明，我们无法通过在计算机上模拟一个程序来预测它是否会终止。简单来说，不运行程序，就无法预测它的执行路径。((("infinite loops")))图灵完备系统可能进入“无限循环”，这个术语（虽有些过于简化）指的是程序不会终止。构造一个永不结束的循环程序轻而易举。但无意中的无限循环可能在没有任何预警的情况下出现，这是由于初始条件与代码之间复杂的交互所致。在以太坊中，这带来一个挑战：每个参与节点（客户端）必须验证每笔交易，并运行交易调用的任何智能合约。但正如图灵所证明的，以太坊在不实际运行（并可能永远运行下去）的情况下，无法预测智能合约是否会终止或需要多长时间。无论是偶然还是故意，都可以创建一个智能合约，让节点在尝试验证它时陷入永久运行。这实际上是一种拒绝服务攻击。当然，介于验证只需毫秒和永远运行之间，还有无数令人讨厌的程序，它们浪费资源、膨胀内存、让 CPU 过热，仅仅是浪费资源。在世界计算机中，一个滥用资源的程序就意味着滥用全世界的资源。如果无法提前预测资源使用情况，以太坊如何限制智能合约的资源消耗？
+
+((("EVM (Ethereum Virtual Machine)","gas and")))((("gas","as counter to Turing completeness")))为应对这一挑战，以太坊引入了一种称为_gas_的计量机制。当 EVM 执行智能合约时，它会仔细记录每条指令（计算、数据访问等）。每条指令都有预先设定的 gas 成本。当交易触发智能合约执行时，必须包含一笔 gas，用于设定可在执行中消耗的上限。如果计算消耗的 gas 超出交易可用的数量，EVM 将终止执行。Gas 是以太坊在允许图灵完备计算的同时限制任意程序资源消耗的机制。
+
+接下来要问的是：“如何获得 gas 来为以太坊世界计算机上的计算付费？”你在任何交易所都买不到 gas。((("ether (generally)","gas and")))它只能在交易中购买，而且只能用以太买到。交易需要附带以太，并明确划拨用于购买 gas，同时给出一个可接受的 gas 价格。就像加油站一样，gas 的价格并非固定。Gas 会在交易中被购买，计算执行完成后，未使用的 gas 会退还给交易的发送方。
+
+[[DApp]]
+=== 从通用区块链到去中心化应用（DApp）
+
+((("DApps (decentralized applications)","Ethereum as platform for")))((("Ethereum (generally)","DApps and")))以太坊最初的目标是构建一条可编程的通用区块链，能够适用于多种用途。但很快，以太坊的愿景扩展为提供构建 DApp 平台。DApp 比智能合约有更广泛的视角。至少而言，DApp 由一个智能合约和一个 Web 用户界面组成。从更广泛的角度看，DApp 是构建在开放、去中心化、点对点基础设施服务之上的 Web 应用。
+
+一个 DApp 至少包括：
+
+- 区块链上的智能合约
+- Web 前端用户界面
+
+此外，许多 DApp 还包含其他去中心化组件，例如：
+
+- 去中心化（P2P）的存储协议和平台
+- 去中心化（P2P）的消息协议和平台
+
+[TIP]
+====
+你可能会看到 DApp 被写作 _ÐApps_。字符 Ð 是一个名为“ETH”的拉丁字母，暗指以太坊。要显示该字符，可以使用 Unicode 码位 +0xD0+，或在需要时使用 HTML 字符实体 +eth+（或十进制实体 +#208+）。
+====
+
+[[evolving_WWW]]
+=== 互联网的第三个时代
+
+((("DApps (decentralized applications)","web3 and")))((("Ethereum (generally)","web3 and")))((("web3")))2004 年，“Web 2.0”一词开始流行，用来描述 Web 向用户生成内容、响应式界面和互动性的演进。Web 2.0 不是技术规范，而是一个描述 Web pass:[<span class="keep-together">应用</span>]新重点的术语。
+
+DApp 的概念旨在将万维网带入下一个自然的进化阶段，将去中心化与点对点协议引入 Web 应用的方方面面。描述这一演进的术语是_web3_，也就是 Web 的第三个“版本”。((("Wood, Dr. Gavin","and web3")))该概念由 Dr. Gavin Wood 首先提出，代表着 Web 应用的新愿景和新焦点：从集中所有和管理的应用，转向构建在去中心化协议之上的应用。
+
+在后续章节中，我们将探索以太坊的 web3.js JavaScript 库，该库将运行在浏览器中的 JavaScript 应用与以太坊区块链连接起来。web3.js 还提供了一个名为 _Swarm_ 的 P2P 存储网络接口以及一个名为 _Whisper_ 的 P2P 消息服务接口。借助这些运行在浏览器中的 JavaScript 库组件，开发者便拥有了一整套用于构建 web3 DApp 的应用开发工具。
+
+[[development_culture]]
+=== 以太坊的开发文化
+
+((("development culture, Ethereum")))((("Ethereum (generally)","development culture")))到目前为止，我们已经讨论了以太坊的目标和技术如何不同于比特币等先前的区块链。以太坊的开发文化也大不相同。
+
+((("Bitcoin","development culture")))在比特币中，开发工作遵循保守的原则：所有变更都会经过仔细研究，以确保不会破坏现有系统。大多数情况下，只有在变更保持向后兼容时才会实施。现有客户端可以选择是否升级，即使不升级也能继续运行。
+
+((("backward compatibility, Ethereum vs. Bitcoin")))相比之下，以太坊社区的开发文化更注重未来而非过去。（并非完全严肃的）口号是“快速行动，打破常规”。如果需要变更，就会直接实施，即使这意味着要推翻以往的假设、破坏兼容性或迫使客户端更新。以太坊的开发文化以快速创新、快速演进和愿意部署面向未来的改进为特征，即便要为此牺牲某些向后兼容性。
+
+对于你这位开发者来说，这意味着必须保持灵活，准备好在某些底层假设发生变化时重建基础设施。以太坊开发者面临的一大挑战，是在一个仍在演进的平台上向不可变系统部署代码之间存在固有矛盾。你无法简单地“升级”智能合约，而必须准备好部署新的合约，迁移用户、应用和资金，从头开始。
+
+具有讽刺意味的是，这也意味着构建更具自主性、更少中心化控制的系统这一目标尚未完全实现。自治和去中心化需要比以太坊未来几年内可能提供的更高平台稳定性。为了“进化”平台，你必须准备好废弃并重启智能合约，这意味着你必须对它们保留一定程度的控制权。
+
+不过，从积极的一面看，以太坊发展极其迅速。几乎没有“争论鸡毛蒜皮”的空间。“自行车棚”这一表达指的是围绕细枝末节争执不休，拖累开发进度，例如在核电站后面盖个自行车棚应该怎么建。如果你开始纠结这些小事，可能会突然发现，在你分心的时候，其余开发团队已经改变计划，放弃自行车，改用自动悬浮船了。
+
+最终，以太坊平台的开发速度会放缓，其接口也会趋于固定。但在此期间，创新是驱动力。你最好跟上脚步，因为没人会为你放慢速度。
+
+[[why_learn]]
+=== 为什么要学习以太坊？
+
+((("blockchain","Ethereum as developer&#39;s blockchain")))((("Ethereum (generally)","reasons to learn")))区块链的学习曲线很陡峭，因为它融合了编程、信息安全、密码学、经济学、分布式系统、点对点网络等多个学科。以太坊让这条学习曲线不再那么陡峭，使你能够快速上手。但在看似简单的环境之下，隐藏着更多内容。随着你学习并逐步深入，总会发现另一层复杂性和奇妙之处。
+
+以太坊是学习区块链的绝佳平台，它聚集开发者社区的速度超过任何其他区块链平台。比起其他平台，以太坊更是一条_开发者的区块链_，由开发者为开发者打造。一位熟悉 JavaScript 应用的开发者，可以快速投入以太坊并编写出可运行的代码。在以太坊生命的头几年，人们常穿着印有“只需五行代码就能创建代币”的 T 恤。当然，这是一把双刃剑。写代码容易，但写出_优秀_且_安全_的代码却很难。
+
+[[teaching_objectives]]
+=== 本书将教会你什么
+
+本书将带你深入了解以太坊，并剖析它的每一个组成部分。你将从一笔简单交易开始，解构它的工作原理，构建一个简单合约，对其进行改进，并跟踪它在以太坊系统中的旅程。
+
+你不仅会学到如何使用以太坊、它如何运作，还会理解它为何被设计成现在的样子。你将能够理解各个部分如何工作、如何彼此衔接以及为何如此。(((range="endofrange", startref="ix_01what-is-asciidoc0")))((("account","contract", see="smart contracts")))((("assymetric cryptography", see="public key cryptography")))((("BIPs", see="Bitcoin improvement proposals")))((("burn", see="ether burn")))((("cryptography","asymmetric", see="public key cryptography")))((("decentralized applications", see="DApps")))((("Decentralized Autonomous Organization", see="DAO")))((("default function", see="fallback function")))((("deterministic (seeded) wallets","hierarchical", see="hierarchical deterministic wallets")))((("DoS attacks", see="denial of service attacks")))((("ECDSA", see="Elliptic Curve Digital Signature Algorithm")))((("ETC", see="Ethereum Classic")))((("Ethereum (generally)","clients", see="clients, Ethereum")))((("Ethereum Improvement Proposals", see="EIP entries")))((("Ethereum Name Service", see="ENS")))((("Ethereum Virtual Machine", see="EVM")))((("Externally Owned Account", see="EOA")))((("fees", see="gas")))((("ICOs", see="Initial Coin Offerings")))((("Mastering Ethereum Token", see="METoken")))((("MEW", see="MyEtherWallet")))((("names/naming", see="ENS (Ethereum Name Service)")))((("NFTs", see="nonfungible tokens")))((("PoS", see="proof of stake")))((("PoW", see="proof of work")))((("PoWHC", see="Proof of Weak Hands Coin")))((("Remote Procedure Call (RPC) commands", see="JSON-RPC API")))((("RPC (Remote Procedure Call) commands", see="JSON-RPC API")))((("Secure Hash Algorithm", see="SHA entries")))((("seeded wallets", see="deterministic wallets")))((("smart contracts","Vyper and", see="Vyper")))((("smartphones", see="mobile (smartphone) wallets")))((("storage", see="data storage")))((("SUICIDE", see="SELFDESTRUCT opcode")))((("synchronization", see="fast synchronization")))((("synchronization", see="first synchronization")))((("transaction fees", see="gas")))((("wallets","HD", see="hierarchical deterministic wallets")))((("wallets","MetaMask", see="MetaMask")))

--- a/02intro.zh.asciidoc
+++ b/02intro.zh.asciidoc
@@ -1,0 +1,538 @@
+[[intro_chapter]]
+== 以太坊基础
+
+((("Ethereum (generally)","basics", id="ix_02intro-asciidoc0", range="startofrange")))在本章中，我们将开始探索以太坊，了解如何使用钱包、如何创建交易，以及如何运行一个基础的智能合约。
+
+[[ether_units]]
+=== 以太货币单位
+
+((("currency units")))((("Ethereum (generally)","currency units")))以太坊的货币单位称为_以太_（_ether_），通常写作“ETH”，也可以用符号&#926;（来自形似大写 E 的希腊字母“Xi”）或较少见的&#9830;来表示。例如，1 以太、1 ETH、&#926;1 或 &#9830;1 都代表相同的数额。
+
+[TIP]
+====
+使用 Unicode 字符 +U+039E+ 表示 &#926;，使用 +U+2666+ 表示 &#9830;。
+====
+
+以太可以拆分成更小的单位，直至最小单位 _wei_。1 以太等于 1 百京 wei（1 * 10^18^，即 1,000,000,000,000,000,000）。你可能会听到有人把货币称作“Ethereum”，但这是初学者常犯的错误。Ethereum 指的是系统本身，_以太_才是货币。
+
+在以太坊内部，价值始终以 wei 为单位，用无符号整数来表示。当你转账 1 以太时，交易会将 1000000000000000000 wei 编码为金额。
+
+以太的各种面额既有符合国际单位制（_SI_）的_科学名称_，也有向众多计算机和密码学先驱致敬的俗称。
+
+<<ether_denominations>> 展示了不同单位、对应俗称以及 SI 名称。与内部价值表示方式一致，表格按 wei（第一行）列出所有面额，在第 7 行以 10^18^ wei 标示以太。
+
+[[ether_denominations]]
+.以太面额与单位名称
+[options="header"]
+|===
+| Value (in wei) | Exponent | Common name | SI name
+| 1 | 1 | wei | Wei
+| 1,000 | 10^3^ | Babbage | Kilowei or femtoether
+| 1,000,000 | 10^6^ | Lovelace | Megawei or picoether
+| 1,000,000,000 | 10^9^ | Shannon | Gigawei or nanoether
+| 1,000,000,000,000 | 10^12^ | Szabo | Microether or micro
+| 1,000,000,000,000,000 | 10^15^ | Finney | Milliether or milli
+| _1,000,000,000,000,000,000_ | _10^18^_ | _Ether_ | _Ether_
+| 1,000,000,000,000,000,000,000 | 10^21^ | Grand | Kiloether
+| 1,000,000,000,000,000,000,000,000 | 10^24^ | | Megaether
+|===
+
+[[choosing_eth_wallet]]
+=== 选择以太坊钱包
+
+((("Ethereum (generally)","wallet choices")))((("wallets","choosing")))((("wallets","defined")))“钱包”这个词如今涵盖了很多含义，尽管它们都彼此相关，并且在日常使用中几乎可以互换。我们把“钱包”理解为帮助你管理以太坊账户的软件应用。简而言之，以太坊钱包是你进入以太坊系统的入口。它保管你的密钥，并可以代表你创建和广播交易。选择以太坊钱包可能会让人犯难，因为可选项众多、功能设计各异。有的更适合新手，有的更适合专家。以太坊平台本身仍在不断改进，而“最好的”钱包往往是那些能够适应平台升级所带来的变化的产品。
+
+不过别担心！如果你选择了一个钱包却不喜欢它的工作方式——或者一开始喜欢，后来想尝试别的——更换钱包非常容易。你只需要发起一笔交易，将资金从旧钱包发送到新钱包，或者导出你的私钥并导入到新钱包中即可。
+
+我们精选了几种类型的钱包，作为全书的示例。有些适用于移动端，有些适用于桌面，还有一些基于网页。我们选择它们是因为它们覆盖了功能和复杂度的广泛范围。但这并不意味着我们认可它们的质量或安全性，它们只是演示和测试的起点。
+
+((("private keys","wallets and")))请记住，要让钱包应用正常工作，它必须能够访问你的私钥，因此务必只从可信来源下载和使用钱包应用。通常而言，钱包越受欢迎，可信度往往越高。不过，把所有鸡蛋放在同一个篮子里总不是好主意，最好将以太坊账户分散在多个钱包中。
+
+以下是一些不错的入门钱包：
+
+MetaMask:: ((("MetaMask")))MetaMask 是运行在浏览器中的扩展钱包（Chrome、Firefox、Opera 或 Brave Browser）。它易于使用，且因能够连接多种以太坊节点和测试链而非常适合测试。MetaMask 虽然是基于网页的钱包，但也提供 iOS 和 Android 的移动应用。
+
+Jaxx:: ((("Jaxx")))((("wallets","Jaxx")))Jaxx 是一款多平台、多币种钱包，可运行在 Android、iOS、Windows、macOS 和 Linux 等多种操作系统上。它注重简单易用，常被推荐给新用户。根据安装位置不同，Jaxx 可以是移动钱包，也可以是桌面钱包。
+
+MyEtherWallet (MEW):: ((("MyEtherWallet (MEW)")))((("wallets","MyEtherWallet")))MyEtherWallet 主要是一个运行于任意浏览器的网页钱包，也提供 Android 和 iOS 版本。它具备多种复杂功能，我们会在后续示例中逐一探索。
+
+Emerald Wallet:: ((("Ethereum Classic (ETC)","Emerald Wallet and")))((("wallets","Emerald Wallet")))((("Emerald Wallet")))Emerald Wallet 为 Ethereum Classic 区块链设计，同时兼容其他以太坊系区块链。这是一款开源桌面应用，可运行于 Windows、macOS 和 Linux。Emerald Wallet 既可以运行全节点，也可以以“轻量”模式连接公共远程节点。它还提供一个配套的命令行工具，便于通过命令行执行所有操作。
+
+我们将从在桌面上安装 MetaMask 开始，但在此之前，先简单聊聊如何控制和管理密钥。
+
+[[control_responsibility]]
+=== 控制与责任
+
+((("Ethereum (generally)","control and responsibility", id="ix_02intro-asciidoc1", range="startofrange")))像以太坊这样的开放区块链之所以重要，是因为它们作为_去中心化_系统运行。这意味着很多事情，但其中一个关键点在于，每个以太坊用户都能够——也应该——控制自己的私钥，而私钥正是掌管资金和智能合约访问权限的关键。我们有时会把对资金和智能合约的访问组合称为“账户”或“钱包”。这些术语背后包含的功能可能很复杂，我们稍后会详细解释。不过，作为基本原则，你可以把它理解为：一个私钥对应一个“账户”。有些用户会选择把私钥交由第三方托管，例如在线交易所。在本书中，我们将教你如何掌控并管理自己的私钥。
+
+掌控带来重大责任。如果你丢失了私钥，就失去了对资金和合约的访问权。没有人能帮你找回——资金将永远被锁定。以下是一些帮助你承担这份责任的提示：
+
+* 不要自行发明安全措施。要使用经过验证的标准方法。
+
+* 账户越重要（例如资金价值越高或可访问的智能合约越关键），就应采取越严格的安全措施。
+
+* 最高等级的安全性来自与互联网隔离的设备（air-gapped device），但并非每个账户都需要这种级别。
+
+* 切勿以明文存储私钥，尤其不要以数字形式保存。值得庆幸的是，大多数现代用户界面甚至不会让你直接看到原始私钥。
+
+* ((("private keys","wallets and")))私钥可以以加密形式存储为数字“密钥库”文件。由于经过加密，解锁时需要密码。当你被要求设置密码时，请确保它足够强（即长度足够、随机性高），做好备份，并且不要分享。如果没有密码管理器，就把密码写下来，并保存在安全、秘密的位置。访问账户时，你需要密钥库文件和密码。
+
+* 不要把任何密码存放在数字文档、电子照片、截图、在线云盘、加密 PDF 等地方。再次强调，不要自行发明安全措施。请使用密码管理器或纸笔。
+
+* 当系统提示你将密钥备份为助记词（单词序列）时，请用纸笔做好实体备份。不要拖延，否则你会忘记。这些备份可以在系统数据全部丢失，或你忘记/遗失密码时，重建你的私钥。但攻击者也可以利用它们窃取你的私钥，因此切勿以数字形式保存，并把纸质备份妥善存放在上锁的抽屉或保险箱中。
+
+* 在转账大额资金前（尤其是转向新地址），先试一笔小额测试交易（例如不到 1 美元），并等待对方确认收到。
+
+* 创建新账户时，先向新地址发送一笔小额测试交易。收到后，再尝试从该账户发回一笔。有很多原因会导致账户创建失败，如果真出了问题，最好只是小损失。如果测试顺利，则一切就绪。
+
+* 公共区块浏览器可以让你独立查看交易是否被网络接受。不过，这种便利会影响隐私，因为你将地址暴露给区块浏览器，后者可能对你进行跟踪。
+
+* 不要向本书展示的任何地址汇款。这些地址的私钥已在书中公布，任何人都可以立即转走你的资金。
+
+现在我们已经了解了密钥管理和安全的一些基本最佳实践，接下来就动手使用 MetaMask 吧！(((range="endofrange", startref="ix_02intro-asciidoc1")))
+
+[[installing_MetaMask]]
+=== MetaMask 入门
+
+((("Ethereum (generally)","MetaMask basics", id="ix_02intro-asciidoc2", range="startofrange")))((("MetaMask","basics", id="ix_02intro-asciidoc3", range="startofrange")))打开 Google Chrome 浏览器，访问 https://chrome.google.com/webstore/category/extensions[]。
+
+搜索“MetaMask”，并点击狐狸头像的图标。你看到的页面应与 <<metamask_download>> 中展示的结果类似。
+
+[[metamask_download]]
+.MetaMask Chrome 扩展的详情页
+image::images/metamask_download.png["MetaMask Detail Page"]
+
+确认自己下载的是正版 MetaMask 非常重要，因为偶尔会有人设法让恶意扩展绕过 Google 的审查。正版扩展具有以下特征：
+
+* 地址栏中显示 ID +nkbihfbeogaeaoehlefnkodbefgpgknn+
+* 由 https://metamask.io 提供
+* 拥有超过 1,500 条评价
+* 拥有超过 1,000,000 名用户
+
+确认无误后，点击“Add to Chrome”进行安装。
+
+[[using_MetaMask]]
+==== 创建钱包
+
+((("MetaMask","wallet setup with", id="ix_02intro-asciidoc4", range="startofrange")))安装完成后，你应该会在浏览器工具栏看到新的狐狸图标。点击它开始使用。系统会让你接受条款与条件，然后输入密码创建新的以太坊钱包（见 <<metamask_password>>）。
+
+[[metamask_password]]
+.MetaMask Chrome 扩展的密码页面
+image::images/metamask_password.png["MetaMask Password Page"]
+
+[TIP]
+====
+该密码用于保护 MetaMask，防止任何能访问你浏览器的人直接使用它。
+====
+
+((("mnemonic code words","MetaMask and", id="ix_02intro-asciidoc5", range="startofrange")))设置密码后，MetaMask 会为你生成一个钱包，并展示由 12 个英文单词组成的_助记词备份_（见 <<metamask_mnemonic>>）。如果 MetaMask 或你的电脑出现问题，这些单词可以在任意兼容钱包中恢复资金访问。恢复时不需要密码，12 个单词就足够了。
+
+[TIP]
+====
+把助记词（12 个单词）抄写在纸上，一式两份。将两份纸质备份存放在两个分开的安全地点，比如防火保险箱、上锁的抽屉或银行保险柜。将纸质备份视作与你以太坊钱包中资产价值相当的现金。任何获取这些单词的人都能访问并盗走你的资金。
+====
+
+[[metamask_mnemonic]]
+.MetaMask 为你的钱包生成的助记词备份
+image::images/metamask_mnemonic.png["MetaMask Mnemonic Page"]
+
+确认你已经妥善保存助记词后，就能看到以太坊账户的详细信息，如 <<metamask_account>> 所示。(((range="endofrange", startref="ix_02intro-asciidoc5")))
+
+[[metamask_account]]
+.MetaMask 中的以太坊账户
+image::images/metamask_account.png["MetaMask Account Page"]
+
+账户页面会显示账户名称（默认是“Account 1”）、一个以太坊地址（示例中为 +0x9E713...+），以及一个彩色图标，帮助你在视觉上区分不同账户。页面顶部可以看到当前所连接的以太坊网络（示例中为“Main Network”）。
+
+恭喜你，已经设置好第一个以太坊钱包！(((range="endofrange", startref="ix_02intro-asciidoc4")))
+
+[[switching_networks]]
+==== 切换网络
+
+((("MetaMask","network choices")))如你在 MetaMask 账户页面所见，你可以在多个以太坊网络之间切换。默认情况下，MetaMask 会尝试连接主网。其他选项包括公共测试网、任意你选择的以太坊节点，或运行在本机（localhost）的私有区块链节点：
+
+Main Ethereum Network:: 以太坊主网。真正的 ETH、真正的价值，以及真实的后果。
+
+Ropsten Test Network:: 以太坊公共测试链与网络。该网络上的 ETH 没有任何价值。
+
+Kovan Test Network:: 采用 Aura 共识协议（授权证明，federated signing）的以太坊公共测试链与网络。该网络上的 ETH 没有价值。Kovan 测试网仅由 Parity 支持。其他以太坊客户端在较晚提出的 Clique 共识协议下实现授权证明。
+
+Rinkeby Test Network:: 采用 Clique 共识协议（授权证明，federated signing）的以太坊公共测试链与网络。该网络上的 ETH 没有价值。
+
+Localhost 8545:: 连接运行在与浏览器相同电脑上的节点。该节点可以属于任意公共区块链（主网或测试网），也可以是私有测试网。
+
+Custom RPC:: 允许你将 MetaMask 连接到任何具有 Geth 兼容远程过程调用（RPC）接口的节点。该节点可以属于任意公共或私有区块链。
+
+[NOTE]
+====
+MetaMask 钱包在连接到不同网络时会使用相同的私钥和以太坊地址。然而，你的以太坊地址在每个网络上的余额会不同。例如，你的密钥或许能在 Ropsten 控制以太和合约，但在主网上却没有。
+====
+
+[[getting_test_eth]]
+==== 获取测试以太
+
+((("ether (generally)","testnet")))((("MetaMask","and testnet ether")))((("test ether","obtaining")))((("testnet","ether for")))((("wallets","testnet ether and")))你的第一项任务是为钱包充值。我们不会在主网上操作，因为真实的以太需要花钱，而且处理它需要更多经验。现在，我们先给钱包充入一些测试网以太。
+
+((("Ropsten Test Network")))将 MetaMask 切换到_Ropsten Test Network_。点击 Deposit，再点击 Ropsten Test Faucet。MetaMask 会打开一个新网页，如 <<metamask_ropsten_faucet>> 所示。
+
+[[metamask_ropsten_faucet]]
+.MetaMask Ropsten 测试水龙头
+image::images/metamask_ropsten_faucet.png["MetaMask Ropsten Test Faucet"]
+
+你可能会注意到，该网页已经包含了 MetaMask 钱包的以太坊地址。MetaMask 会将启用以太坊功能的网页与你的钱包集成，它能“看到”网页上的以太坊地址，例如帮助你向显示以太坊地址的在线商店付款。如果网页提出请求，MetaMask 也能将你自己的钱包地址填入网页中的收款地址。在本页中，水龙头应用正在向 MetaMask 请求一个钱包地址，以便发送测试以太。
+
+点击绿色的“request 1 ether from faucet”按钮。页面下方会出现一个交易 ID，说明水龙头应用已经创建了一笔交易——向你付款。该交易 ID 类似如下：
+
+[[faucet_tx_id]]
+----
+0x7c7ad5aaea6474adccf6f5c5d6abed11b70a350fbc6f9590109e099568090c57
+----
+
+几秒钟后，Ropsten 矿工就会把这笔新交易打包，你的 MetaMask 钱包将显示 1 ETH 的余额。点击交易 ID，浏览器会跳转到_区块浏览器_，这是一种允许你可视化和探索区块、地址以及交易的网站。MetaMask 使用的是 https://etherscan.io/[Etherscan 区块浏览器]，这是最受欢迎的以太坊区块浏览器之一。包含这笔 Ropsten 测试水龙头付款的交易如 <<ropsten_block_explorer>> 所示。
+
+[[ropsten_block_explorer]]
+.Etherscan Ropsten 区块浏览器
+image::images/ropsten_block_explorer.png["Etherscan Ropsten Block Explorer"]
+
+这笔交易已经记录在 Ropsten 区块链上，任何人都可以随时查看，只需搜索交易 ID，或 http://bit.ly/2Q860Wk[访问该链接]。
+
+试着访问这个链接，或在 _ropsten.etherscan.io_ 网站上输入交易哈希，亲自查看一下。
+
+[[sending_eth_MetaMask]]
+==== 从 MetaMask 发送以太
+
+((("MetaMask","sending ether from", id="ix_02intro-asciidoc6", range="startofrange")))((("test ether","sending", id="ix_02intro-asciidoc7", range="startofrange")))从 Ropsten 测试水龙头收到第一笔测试以太后，就可以尝试发送，以测试向水龙头返还一些以太。你可以看到 Ropsten Test Faucet 页面上有“donate 1 ETH”选项，这样在完成测试后就可以把剩余的测试以太归还，好让其他人也能使用。虽然测试以太没有价值，但有人会囤积，导致其他人难以使用测试网络。囤积测试以太是不被认可的！
+
+所幸我们不是测试以太囤积者。点击橙色的“1 ether”按钮，让 MetaMask 创建一笔向水龙头支付 1 以太的交易。MetaMask 会准备好交易，并弹出一个确认窗口，如 <<send_to_faucet>> 所示。
+
+[[send_to_faucet]]
+.向水龙头发送 1 以太
+image::images/send_to_faucet.png["Sending 1 ether to the faucet"]
+
+糟糕！你可能注意到交易无法完成——MetaMask 提示余额不足。乍一看这很令人困惑：你有 1 ETH，想发送 1 ETH，为什么 MetaMask 却说余额不足？
+
+((("gas","basics")))原因在于_燃料费（gas）_的成本。每笔以太坊交易都需要支付费用，矿工通过验证交易来收取这笔费用。以太坊中的费用以一种称为 gas 的虚拟货币计价，你在交易中使用以太支付 gas。
+
+[NOTE]
+====
+((("gas","on test networks")))测试网络同样需要支付费用。没有费用，测试网络的行为就会不同于主网，从而无法作为合格的测试平台。燃料费还能保护测试网络不受 DoS 攻击和设计糟糕的合约（例如无限循环）的影响，就像保护主网一样。
+====
+
+当你发送交易时，MetaMask 会计算最近成功交易的平均 gas 价格，此处为 3 gwei（gwei 表示 gigawei）。如前文 <<ether_units>> 所述，wei 是以太货币的最小 pass:[<span class="keep-together">子单位</span>]。gas 限额设置为发送基础交易的成本，即 21,000 gas 单位。因此，你需要支付的最大 ETH 数量为 3 * 21,000 gwei = 63,000 gwei = 0.000063 ETH。（请注意，平均 gas 价格会波动，因为它主要由矿工决定。我们会在后续章节看到如何调高/调低 gas 限额，以在需要时让交易获得优先处理。）
+
+总结一下：发起一笔 1 ETH 的交易总成本为 1.000063 ETH。MetaMask 在显示总额时会令人困惑地将其_四舍五入到_ 1 ETH，但实际需要 1.000063 ETH，而你只有 1 ETH。点击 Reject 取消这笔交易。
+
+让我们再获取一些测试以太！再次点击绿色的“request 1 ether from the faucet”按钮，等待几秒钟。别担心，水龙头通常有足够的以太，只要你请求就会发放。
+
+当余额达到 2 ETH 后，再试一次。这次点击橙色的“1 ether”捐赠按钮时，你的余额足以完成交易。MetaMask 弹出支付窗口后，点击 Submit。最后你应该会看到余额变为 0.999937 ETH，因为你向水龙头发送了 1 ETH，并支付了 0.000063 ETH 的 gas。(((range="endofrange", startref="ix_02intro-asciidoc7")))(((range="endofrange", startref="ix_02intro-asciidoc6")))
+
+[[explore_tx_history]]
+==== 查看地址的交易历史
+
+((("addresses","exploring transaction history of", id="ix_02intro-asciidoc8", range="startofrange")))((("MetaMask","exploring transaction history of an address with", id="ix_02intro-asciidoc9", range="startofrange")))此时，你已经熟练掌握使用 MetaMask 发送和接收测试以太。你的钱包至少收到两笔付款，并发送了至少一笔。你可以使用 _ropsten.etherscan.io_ 区块浏览器查看所有这些交易。可以复制你的钱包地址，粘贴到区块浏览器的搜索框，也可以让 MetaMask 替你打开该页面。在 MetaMask 的账户图标旁边，有一个显示三个点的按钮。点击它会打开与账户相关的菜单（见 <<metamask_account_context_menu>>）。
+
+[[metamask_account_context_menu]]
+.MetaMask 账户上下文菜单
+image::images/metamask_account_context_menu.png["MetaMask account context menu"]
+
+[[block_explorer_account_history]]
+.Etherscan 上的地址交易历史
+image::images/block_explorer_account_history.png["Address Transaction History on Etherscan"]
+
+在这里，你可以看到以太坊地址的完整交易历史。页面会展示 Ropsten 区块链上所有以你的地址为发送方或接收方的交易。点击其中几笔交易，可以查看更多详细信息。
+
+你也可以探索任意地址的交易历史。查看一下 Ropsten 测试水龙头地址的交易记录（提示：它是你账户最早那笔收款中的“sender”地址）。你可以看到该水龙头向你以及其他地址发送的所有测试以太。你看到的每笔交易都会引导你发现更多的地址和交易。不久你就会迷失在彼此关联的数据迷宫中。公共区块链蕴藏着海量信息，所有这些信息都可以通过程序化方式进行探索，我们会在后续示例中看到这一点(((range="endofrange", startref="ix_02intro-asciidoc9")))(((range="endofrange", startref="ix_02intro-asciidoc8"))).(((range="endofrange", startref="ix_02intro-asciidoc3")))(((range="endofrange", startref="ix_02intro-asciidoc2")))
+
+[[intro_world_computer]]
+=== 认识世界计算机
+
+((("Ethereum (generally)","and EVM")))((("EVM (Ethereum Virtual Machine)","as world computer")))((("world computer, Ethereum as")))至此，你已经创建了一个钱包，并完成了以太的收发。到目前为止，我们一直把以太坊当作一种加密货币来看待。但以太坊远不止于此。事实上，加密货币功能只是以太坊作为去中心化世界计算机的附属功能。((("smart contracts","ether and")))以太用于支付运行_智能合约_所需的费用，而智能合约则是在一个名为_以太坊虚拟机_（Ethereum Virtual Machine，简称 EVM）的仿真计算机上运行的程序。
+
+EVM 是一个全球单例，这意味着它表现得就像一台在任何地方都存在的全球单实例计算机。以太坊网络上的每个节点都会运行本地副本的 EVM，用于验证合约执行，而以太坊区块链会记录这台世界计算机在处理交易和智能合约时不断变化的_状态_。我们将在 <<evm_chapter>> 中详细讨论。
+
+[[EOA_contracts]]
+=== 外部拥有账户（EOA）与合约
+
+((("contract accounts", seealso="smart contracts")))((("EOA (Externally Owned Account)","basics")))((("Ethereum (generally)","EOAs and contracts")))((("smart contracts","basics")))你在 MetaMask 钱包中创建的账户称为_外部拥有账户_（Externally Owned Account，简称 EOA）。外部拥有账户拥有私钥；掌握私钥就意味着能够控制对资金或合约的访问。你也许已经猜到，还有另一种类型的账户：那就是_合约账户_。合约账户包含智能合约代码，而简单的 EOA 不具备。合约账户没有私钥，它由智能合约代码的逻辑来“拥有”（和控制）：这段在合约账户创建时记录在以太坊区块链上的软件，会由 EVM 执行。
+
+合约拥有地址，就像 EOA 一样。合约也能发送和接收以太，也与 EOA 无异。不过，当交易的目标是合约地址时，会触发合约在 EVM 中_运行_，并使用这笔交易及其数据作为输入。除以太之外，交易还可以包含_数据_，用来指示合约应运行哪个具体函数，以及传入哪些参数。通过这种方式，交易可以_调用_合约中的函数。
+
+请注意，因为合约账户没有私钥，它无法_发起_交易。只有 EOA 能发起交易，而合约可以通过调用其他合约来_响应_交易，构建复杂的执行路径。一个典型的使用场景是，某个 EOA 向多重签名智能合约钱包发送请求交易，由后者再向另一地址转出 ETH。典型的 DApp 编程模式是让合约 A 调用合约 B，以便在合约 A 的用户之间维护共享状态。
+
+接下来的几个小节中，我们将编写第一个合约。之后，你将学习如何在 Ropsten 测试网上，使用 MetaMask 钱包和测试以太来创建、注资并使用该合约。
+
+[[simple_contract_example]]
+=== 简单合约：测试以太水龙头
+
+((("contract accounts","creating", seealso="Faucet.sol contract", id="ix_02intro-asciidoc10", range="startofrange")))((("Faucet.sol contract (test example)","creating", id="ix_02intro-asciidoc11", range="startofrange")))以太坊拥有多种高级语言，都可以用来编写合约并生成 EVM 字节码。你可以在 <<high_level_languages>> 中了解其中许多重要且有趣的语言。Solidity 是目前编写智能合约时最常用的高级语言。((("Wood, Dr. Gavin","and Solidity")))Solidity 由本书合著者 Gavin Wood 博士创建，如今已成为以太坊（以及其他平台）最广泛使用的语言。我们将使用 Solidity 来编写第一个合约。
+
+((("Solidity","faucet.sol and")))在第一个示例（<<solidity_faucet_example>>）中，我们将编写一个控制_水龙头_的合约。你已经使用水龙头在 Ropsten 测试网上获取测试以太。水龙头是个相当简单的机制：任何请求者都能从中领取以太，并且可以定期补充。你可以由人工或 Web 服务器控制的钱包来实现水龙头。
+
+[[solidity_faucet_example]]
+.Faucet.sol：实现水龙头的 Solidity 合约
+====
+[source,solidity,linenums]
+----
+include::code/Solidity/Faucet.sol[]
+----
+====
+
+[NOTE]
+====
+你可以在 https://github.com/ethereumbook/ethereumbook/[本书的 GitHub 仓库] 的 _code_ 子目录中找到所有代码示例。我们的 _Faucet.sol_ 合约位于：
+
+----
+code/Solidity/Faucet.sol
+----
+====
+
+这是一个非常简单的合约，几乎已经简单到极限。但它也是一个_存在缺陷_的合约，包含了不少糟糕的实践和安全漏洞。我们会在后面逐一分析这些缺陷，从中学习。不过现在，我们先逐行理解这个合约的作用和运行方式。你会很快发现，Solidity 的许多元素与现有编程语言（例如 JavaScript、Java 或 Cpass:[++]）非常相似。
+
+第一行是一条注释：
+
+[[comment]]
+[source,solidity]
+----
+// SPDX-License-Identifier: CC-BY-SA-4.0
+----
+
+注释是写给人看的，不会被编译进可执行的 EVM 字节码。我们通常将注释放在所解释代码的上一行，有时也会写在同一行。注释以两个斜杠开头：+//+。从第一个斜杠起到行尾的内容都会像空行一样被忽略。
+
+几行之后，就是我们实际的合约定义：
+
+[[contract_definition]]
+[source,solidity]
+----
+contract Faucet {
+----
+
+这行声明了一个 +contract+ 对象，类似于其他面向对象语言中的 +class+ 声明。合约定义包含花括号 pass:[(<code>{}</code>)] 之间的所有代码，这些花括号定义了一个_作用域_，与许多编程语言中使用花括号的方式类似。
+
+接下来，我们让合约可以接受任意传入金额：
+
+[[receive_function]]
+[source,solidity]
+----
+receive () external payable {}
+----
+
+((("receive function")))如果触发合约的交易没有指定任何已声明的函数，或者交易不包含数据（因此只是普通的以太转账），就会调用 receive 函数。合约最多只能有一个这样的无名 receive 函数，它用于接收以太。因此，我们将其声明为 external 且 payable，也就是它能够接收并接受进入合约的以太。函数体为空的花括号 pass:[(<code>{}</code>)] 表示它除了接收以太之外什么也不做。如果我们向合约地址发送以太（就像对待钱包一样），该函数会负责处理。
+
+之后，我们声明 +Faucet+ 合约的第一个函数：
+
+[[withdraw_function]]
+[source,solidity]
+----
+function withdraw(uint withdraw_amount) public {
+----
+
+该函数名为 +withdraw+，接受一个名为 +withdraw_amount+ 的无符号整数（+uint+）参数。它被声明为 public 函数，意味着其他合约可以调用它。函数定义写在花括号内。+withdraw+ 函数的第一部分设置了取款上限：
+
+[[withdraw_limit]]
+[source,solidity]
+----
+require(withdraw_amount <= 100000000000000000);
+----
+
+这里使用 Solidity 内置函数 +require+ 来测试先决条件，确保 +withdraw_amount+ 小于或等于 100,000,000,000,000,000 wei，这是以太的基础单位（参见 <<ether_denominations>>），相当于 0.1 以太。如果 +withdraw+ 函数在被调用时的 +withdraw_amount+ 超过该值，+require+ 函数会让合约执行停止，并抛出_异常_。请注意，Solidity 中的语句需要以分号结尾。
+
+这部分是水龙头合约的主要逻辑。它通过设置取款上限来控制资金流出。虽然控制方式很简单，但也展示了可编程区块链的力量：去中心化软件可以控制资金。
+
+接下来是真正的提款操作：
+
+[[withdraw_command]]
+[source,solidity]
+----
+msg.sender.transfer(withdraw_amount);
+----
+
+这里发生了几件有趣的事情。+msg+ 对象是所有合约都能访问的输入之一，代表触发当前合约执行的交易。属性 +sender+ 是交易的发送地址。+transfer+ 函数是一个内置函数，它会把以太从当前合约转到发送方地址。换句话说，就是把 +withdraw_amount+ 转给触发此次合约执行的 +msg+ 的 +sender+。+transfer+ 函数仅接受一个参数，即转账金额。我们把几行前函数参数 +withdraw_amount+ 传给它。
+
+紧接着下一行的右花括号表示 +withdraw+ 函数定义的结束。
+
+再往下的最后一个右花括号标志着 +Faucet+ 合约定义的结束。就是这么简单！(((range="endofrange", startref="ix_02intro-asciidoc11")))(((range="endofrange", startref="ix_02intro-asciidoc10")))
+
+[[compile_faucet_contract]]
+=== 编译水龙头合约
+
+((("compiling","Faucet.sol contract", id="ix_02intro-asciidoc12", range="startofrange")))((("Faucet.sol contract (test example)","compiling", id="ix_02intro-asciidoc13", range="startofrange")))现在我们有了第一个合约示例，需要使用 Solidity 编译器将 Solidity 代码转换为 EVM 字节码，以便 EVM 在区块链上执行。
+
+Solidity 编译器可以作为独立可执行文件，也可以作为各种框架的一部分，还可以与集成开发环境（IDE）打包。为求简单，我们将使用最受欢迎的 IDE 之一——_Remix_。
+
+((("Remix IDE")))在安装好 MetaMask 的 Chrome 浏览器中，访问 https://remix.ethereum.org[] 打开 Remix IDE。
+
+首次加载 Remix 时，它会打开一个名为 _ballot.sol_ 的示例合约。我们不需要它，可以点击标签页角落的 +x+ 关闭，如 <<remix_close_tab>> 所示。
+
+[[remix_close_tab]]
+.关闭默认示例标签页
+image::images/remix_close_tab.png["Close the default example tab"]
+
+现在，点击左上角工具栏中的圆形加号打开新标签页，如 <<remix_toolbar>> 所示。将新文件命名为 _Faucet.sol_。
+
+[[remix_toolbar]]
+.点击加号打开新标签页
+image::images/remix_toolbar.png["Click the plus sign to open a new tab"]
+
+打开新标签后，把示例中的 _Faucet.sol_ 代码复制粘贴进去，如 <<remix_faucet_load>> 所示。
+
+[[remix_faucet_load]]
+.将 Faucet 示例代码复制到新标签
+image::images/remix_faucet_load.png["Copy the Faucet example code into the new tab"]
+
+当 _Faucet.sol_ 合约载入 Remix IDE 后，IDE 会自动编译代码。如果一切顺利，你会在右侧的 Compile 选项卡下看到绿色的“Faucet”框，表示编译成功（见 <<remix_compile>>）。
+
+[[remix_compile]]
+.Remix 成功编译 Faucet.sol 合约
+image::images/remix_compile.png[""]
+
+如果出现问题，很可能是 Remix IDE 使用的 Solidity 编译器版本不是 0.6。在这种情况下，我们的 pragma 指令会阻止 _Faucet.sol_ 编译。要更改编译器版本，请前往 Settings 选项卡，将版本设置为 0.6.0，然后重试。
+
+现在，Solidity 编译器已经将 _Faucet.sol_ 编译成 EVM 字节码。如果你好奇，字节码大致如下所示：
+
+[[faucet_bytecode]]
+----
+PUSH1 0x80 PUSH1 0x40 MSTORE CALLVALUE DUP1 ISZERO PUSH2 0x10 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0xF4 DUP1 PUSH2 0x1F PUSH1 0x0 CODECOPY PUSH1 0x0 RETURN INVALID PUSH1 0x80 PUSH1 0x40 MSTORE PUSH1 0x4 CALLDATASIZE LT PUSH1 0x1F JUMPI PUSH1 0x0 CALLDATALOAD PUSH1 0xE0 SHR DUP1 PUSH4 0x2E1A7D4D EQ PUSH1 0x2A JUMPI PUSH1 0x25 JUMP JUMPDEST CALLDATASIZE PUSH1 0x25 JUMPI STOP JUMPDEST PUSH1 0x0 DUP1 REVERT JUMPDEST CALLVALUE DUP1 ISZERO PUSH1 0x35 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x5F PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x20 DUP2 LT ISZERO PUSH1 0x4A JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 ADD SWAP1 DUP1 DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP1 SWAP3 SWAP2 SWAP1 POP POP POP PUSH1 0x61 JUMP JUMPDEST STOP JUMPDEST PUSH8 0x16345785D8A0000 DUP2 GT ISZERO PUSH1 0x75 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST CALLER PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH2 0x8FC DUP3 SWAP1 DUP2 ISZERO MUL SWAP1 PUSH1 0x40 MLOAD PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP6 DUP9 DUP9 CALL SWAP4 POP POP POP POP ISZERO DUP1 ISZERO PUSH1 0xBA JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP JUMP INVALID LOG2 PUSH5 0x6970667358 0x22 SLT KECCAK256 STOP CODECOPY 0xDC DUP16 0xD SGT PUSH6 0xD2245039EDD7 RETURN CALLDATALOAD 0xC2 0xE4 SWAP9 0xF6 0x2C 0xF8 0xB3 OR JUMPDEST 0xAC 0xD8 CREATE2 SSTORE 0x4E SIGNEXTEND PUSH4 0x3164736F PUSH13 0x634300060C0033000000000000
+----
+
+庆幸我们使用的是像 Solidity 这样的高级语言，而不是直接用 EVM 字节码编程吧！我也这么想。(((range="endofrange", startref="ix_02intro-asciidoc13")))(((range="endofrange", startref="ix_02intro-asciidoc12")))
+
+[[create_contract]]
+=== 在区块链上创建合约
+
+((("blockchain","creating contract on", id="ix_02intro-asciidoc14", range="startofrange")))((("Faucet.sol contract (test example)","on the blockchain", id="ix_02intro-asciidoc15", range="startofrange")))至此，我们已经拥有一个合约，并把它编译成字节码。接下来要做的，是将合约“注册”到以太坊区块链上。我们将在 Ropsten 测试网上部署合约，因此需要向这条链提交合约。
+
+((("zero address","contract registration")))在区块链上注册合约需要创建一笔特殊交易，其目标地址为 +0x0000000000000000000000000000000000000000+，也被称为_零地址_。零地址是以太坊用来指示“我要注册合约”的特殊地址。幸运的是，Remix IDE 会帮你完成这一切，并把交易发送到 MetaMask。
+
+((("Remix IDE", id="ix_02intro-asciidoc16", range="startofrange")))首先切换到 Run 选项卡，在 Environment 下拉框中选择 Injected Web3。这样就把 Remix IDE 连接到 MetaMask 钱包，而 MetaMask 又会连接到 Ropsten 测试网络。完成后，你会在 Environment 下看到 Ropsten，并且 Account 下拉框会显示你的钱包地址（见 <<remix_run>>）。
+
+[[remix_run]]
+.Remix IDE 的 Run 选项卡，已选择 Injected Web3 环境
+image::images/remix_run.png["Remix IDE Run tab, with Injected Web3 environment selected"]
+
+在刚确认过的 Run 设置下方，就是可以创建的 +Faucet+ 合约。点击 <<remix_run>> 中的 Deploy 按钮。
+
+Remix 会构造这笔特殊的“创建”交易，MetaMask 则会弹出窗口请你确认，如 <<remix_metamask_create>> 所示。你会注意到这笔合约创建交易不携带以太，但包含 275 字节的数据（即编译后的合约），并会消耗 3 gwei 的 gas。点击 Confirm 批准它。
+
+[[remix_metamask_create]]
+.MetaMask 展示合约创建交易
+image::images/remix_metamask_create.png["MetaMask showing the contract creation transaction"]
+
+接下来要稍等片刻。合约需要大约 15 到 30 秒才能在 Ropsten 上被打包。Remix 表面上似乎没有什么动静，请耐心等待。
+
+合约创建完成后，它会显示在 Run 选项卡的底部（见 <<remix_contract_interact>>）。
+
+[[remix_contract_interact]]
+.Faucet 合约“上线”啦！
+image::images/remix_contract_interact.png["The Faucet contract is ALIVE!"]
+
+注意，此时 +Faucet+ 合约已经拥有自己的地址：Remix 会显示“Faucet at 0x72e...c7829”（你的地址会有所不同）。右侧的小剪贴板图标可以把合约地址复制到剪贴板，我们将在下一节用到它。(((range="endofrange", startref="ix_02intro-asciidoc16")))(((range="endofrange", startref="ix_02intro-asciidoc15")))
+
+[[interact_contract]]
+=== 与合约交互
+
+((("Faucet.sol contract (test example)","interacting with", id="ix_02intro-asciidoc17", range="startofrange")))让我们回顾一下：以太坊合约是运行在名为 EVM 的虚拟机中的程序，用于控制资金。它们通过一笔特殊交易被创建，这笔交易会把字节码提交到区块链上。合约一旦在链上创建，就像钱包一样拥有一个以太坊地址。任何人向合约地址发送交易，都会让合约在 EVM 中运行，并把该交易作为输入。发送到 pass:[<span class="keep-together">合约</span>] 地址的交易可以携带以太或数据，甚至两者兼有。如果包含以太，就会被“存入”合约余额；如果包含数据，数据可以指定要调用的函数，并向其传递参数。
+
+[[view_contract_address]]
+==== 在区块浏览器中查看合约地址
+
+((("Faucet.sol contract (test example)","viewing contract address in a block explorer")))现在，合约已经记录在区块链上，我们也能看到它的以太坊地址。让我们到 _ropsten.etherscan.io_ 区块浏览器中看看合约的样子。在 Remix IDE 中，点击合约名称旁的剪贴板图标复制地址（见 <<remix_contract_address>>）。
+
+[[remix_contract_address]]
+.从 Remix 中复制合约地址
+image::images/remix_contract_address.png["Copy the contract address from Remix"]
+
+保持 Remix 打开，稍后还会用到。现在在浏览器中访问 _ropsten.etherscan.io_，把刚才复制的地址粘贴到搜索框中。你会看到该合约的以太坊地址历史，如 <<etherscan_contract_address>> 所示。(((range="endofrange", startref="ix_02intro-asciidoc17")))
+
+[[etherscan_contract_address]]
+.在 Etherscan 区块浏览器中查看 Faucet 合约地址
+image::images/etherscan_contract_address.png["View the Faucet contract address in the etherscan block explorer"]
+
+[[fund_contract]]
+==== 为合约注资
+
+((("Faucet.sol contract (test example)","sending ether to", id="ix_02intro-asciidoc18", range="startofrange")))目前，合约历史中只有一笔交易：创建合约的交易。正如你所见，合约的余额也为零，因为我们在创建交易中没有向合约发送任何以太（虽然我们完全可以这么做）。
+
+水龙头需要资金！我们的第一个任务，就是使用 MetaMask 向合约发送以太。此时你的剪贴板里应该还保留着合约地址（如果没有，请在 Remix 中重新复制）。打开 MetaMask，像向其他任意以太坊地址转账那样，向它发送 1 以太（见 <<metamask_send_to_contract>>）。
+
+[[metamask_send_to_contract]]
+.向合约地址发送 1 以太
+image::images/metamask_send_to_contract.png[""]
+
+大约过一分钟，刷新 Etherscan 区块浏览器，就会看到一笔新的交易进入合约地址，余额也更新为 1 以太。
+
+还记得 _Faucet.sol_ 代码中那个无名的 external payable 函数吗？它看起来像这样：
+
+[[receive_function_review]]
+[source,solidity]
+----
+receive () external payable {}
+----
+
+当你向合约地址发送交易且没有指定要调用的函数时，就会触发这个默认函数。由于我们将其声明为 +payable+，它会接受并把 1 以太存入合约账户余额。你的交易让合约在 EVM 中运行并更新了余额。你已经为自己的水龙头完成注资了！(((range="endofrange", startref="ix_02intro-asciidoc18")))
+
+[[withdraw_from_contract]]
+==== 从合约中提款
+
+((("Faucet.sol contract (test example)","withdrawing funds from", id="ix_02intro-asciidoc19", range="startofrange")))((("withdrawal of funds from contract", id="ix_02intro-asciidoc20", range="startofrange")))接下来，让我们从水龙头提取一些资金。提款需要构造一笔交易，调用 +withdraw+ 函数并传入 +withdraw_amount+ 参数。为简单起见，我们让 Remix 帮我们构造这笔交易，MetaMask 则负责弹出确认。
+
+回到 Remix 标签页，在 Run 选项卡中找到合约。你会看到一个橙色的 +withdraw+ 按钮和一个名为 +uint256 withdraw_amount+ 的输入框（见 <<remix_contract_withdraw>>）。
+
+[[remix_contract_withdraw]]
+.Remix 中 Faucet.sol 的 withdraw 函数
+image::images/remix_contract_interact.png["The withdraw function of Faucet.sol, in Remix"]
+
+这是 Remix 与合约交互的界面，可以帮助我们构造调用合约函数的交易。我们将在输入框中填入 +withdraw_amount+，然后点击 withdraw 按钮来生成交易。
+
+首先确定 +withdraw_amount+ 的数值。我们希望尝试提现 0.1 以太，这是合约允许的最大取款金额。记住，以太坊内部的货币值都以 wei 表示，而 +withdraw+ 函数也期望以 wei 为单位。因此我们需要输入的金额是 0.1 以太，即 100,000,000,000,000,000 wei（1 后面带 17 个零）。
+
+[TIP]
+====
+由于 JavaScript 的限制，像 10^17 这么大的数字无法直接由 Remix 处理。因此，我们需要用双引号将其包裹，使 Remix 将其视为字符串并按 +BigNumber+ 处理。如果不加引号，Remix IDE 会处理失败并显示 “Error encoding arguments: Error: Assertion failed.”
+====
+
+在 +withdraw_amount+ 输入框中输入 "100000000000000000"（包括引号），然后点击 withdraw 按钮（见 <<remix_withdraw>>）。
+
+[[remix_withdraw]]
+.在 Remix 中点击“withdraw”创建提款交易
+image::images/remix_withdraw.png[""]
+
+MetaMask 会弹出交易窗口让你确认。点击 Confirm，将调用 withdraw 函数的交易发送出去（见 <<metamask_withdraw>>）。
+
+[[metamask_withdraw]]
+.MetaMask 中调用 withdraw 函数的交易
+image::images/metamask_withdraw.png["MetaMask transaction to call the withdraw function"]
+
+等待片刻，然后刷新 Etherscan 区块浏览器，在 +Faucet+ 合约地址历史中看到这笔交易（见 <<etherscan_withdrawal_tx>>）。
+
+[[etherscan_withdrawal_tx]]
+.Etherscan 显示调用 withdraw 函数的交易
+image::images/etherscan_withdrawal_tx.png["Etherscan shows the transaction calling the withdraw function"]
+
+我们看到一笔新交易，其目标是合约地址，金额为 0 以太。合约余额已经变化为 0.9 以太，因为它按照请求向我们发送了 0.1 以太。但我们在_合约地址历史_中没有看到“OUT”交易。
+
+提款去哪里了？合约地址历史页面出现了一个名为 Internal Transactions 的新标签。((("internal transaction (message)")))因为这笔 0.1 以太是由合约代码发出的，所以它是一笔内部交易（也称为_消息_）。点击该标签即可看到相关记录（见 <<etherscan_withdrawal_internal>>）。
+
+[[etherscan_withdrawal_internal]]
+.Etherscan 显示合约转出以太的内部交易
+image::images/etherscan_withdrawal_internal.png["Etherscan shows the internal transaction transferring ether out from the contract"]
+
+这笔“内部交易”由合约中的以下代码触发（来自 _Faucet.sol_ 的 pass:[<code><span class="keep-together">withdraw</span></code>] 函数）：
+
+[[withdraw_command_review]]
+[source,solidity]
+----
+msg.sender.transfer(withdraw_amount);
+----
+
+总结一下：你从 MetaMask 钱包发出了一笔交易，其中包含调用 +withdraw+ 函数并传入 0.1 以太作为 +withdraw_amount+ 的指令。该交易促使合约在 EVM 中运行。当 EVM 执行 +Faucet+ 合约的 +withdraw+ 函数时，首先调用 +require+，验证所请求金额不超过 0.1 以太的上限。随后调用 +transfer+，向你发送这笔以太。执行 +transfer+ 时产生了一笔内部交易，将 0.1 以太从合约余额转入你的钱包地址。这就是你在 Etherscan 的 Internal Transactions 标签中看到的记录(((range="endofrange", startref="ix_02intro-asciidoc20")))(((range="endofrange", startref="ix_02intro-asciidoc19"))).(((range="endofrange", startref="ix_02intro-asciidoc14")))
+
+[[intro_conclusion]]
+=== 小结
+
+在本章中，你使用 MetaMask 设置了一个钱包，并在 Ropsten 测试网上通过水龙头为其充值。你向钱包的以太坊地址收款，又向水龙头的地址付款。
+
+随后，你用 Solidity 编写了一个水龙头合约。你使用 Remix IDE 将该合约编译成 EVM 字节码，并借助 Remix 构造交易，在 Ropsten 区块链上创建了 +Faucet+ 合约。合约创建后拥有自己的以太坊地址，你向其发送了以太。最后，你构造了一笔交易调用 +withdraw+ 函数，成功领取了 0.1 以太。合约检查了请求，并通过内部交易向你发送 0.1 以太。
+
+看似简单，但你已经成功地与运行在去中心化世界计算机上的“掌控资金的软件”互动。
+
+我们将在 <<smart_contracts_chapter>> 中进行更多智能合约编程，并在 <<smart_contract_security>> 中了解最佳实践与安全考量。(((range="endofrange", startref="ix_02intro-asciidoc0")))

--- a/03clients.zh.asciidoc
+++ b/03clients.zh.asciidoc
@@ -1,0 +1,498 @@
+[[ethereum_clients_chapter]]
+== 以太坊客户端
+
+((("clients, Ethereum", id="ix_03clients-asciidoc0", range="startofrange")))以太坊客户端是一种遵循以太坊规范、并在点对点网络上与其他以太坊客户端通信的软件应用。只要遵守参考规范和标准化通信协议，不同的以太坊客户端就可以实现_互操作_。尽管这些客户端由不同的团队以不同的编程语言实现，它们都“说”同一种协议、遵循同一套规则。因此，它们都能够用来操作并与同一条以太坊网络进行交互。
+
+以太坊是一个开源项目，所有主流客户端的源代码都以开源许可（例如 LGPL v3.0）发布，任何人都可以免费下载并用于任何用途。但“_开源_”不仅意味着免费使用，它还意味着以太坊由开放的志愿者社区开发，并且任何人都可以修改代码。人越多、代码越可信。
+
+((("Yellow Paper specification")))以太坊由一份名为《Yellow Paper》的形式化规范（参见<<references>>）所定义。
+
+((("Bitcoin","Ethereum definition compared to")))相比之下，比特币并没有任何形式化定义。比特币的“规范”是参考实现 Bitcoin Core，而以太坊的规范则记录在一份将英文描述与数学（形式化）描述结合的论文中。这份形式化规范以及各种以太坊改进提案共同定义了以太坊客户端的标准行为。《Yellow Paper》会随着以太坊重大变更而定期更新。
+
+正因为以太坊拥有清晰的形式化规范，才会出现许多独立开发、但能够互操作的客户端实现。以太坊在网络上运行的实现多样性胜过任何其他区块链，这通常被视为一件好事。事实也证明，这是一种抵御网络攻击的绝佳方式：某个客户端的实现策略被利用时，只会让该客户端的开发者忙于修复，而其他客户端几乎不受影响地让网络继续运行。
+
+=== 以太坊网络
+
+((("clients, Ethereum","Ethereum-based networks and", id="ix_03clients-asciidoc1", range="startofrange")))((("networks (Ethereum)","clients and", id="ix_03clients-asciidoc2", range="startofrange")))存在多种基于以太坊的网络，它们大体符合《Yellow Paper》中的形式化规范，但彼此之间可能互操作也可能不能。
+
+这些基于以太坊的网络包括 Ethereum、Ethereum Classic、Ella、Expanse、Ubiq、Musicoin 等。虽然在协议层面大体兼容，但这些网络常常拥有某些特性或属性，使得客户端维护者必须作出一些小调整才能支持各自的网络。因此，并非每个版本的以太坊客户端软件都能运行所有基于以太坊的区块链。
+
+目前，以太坊协议主要有六种实现，分别使用六种不同的编程语言编写：
+
+* Parity，使用 Rust 编写
+* Geth，使用 Go 编写
+* +cpp-ethereum+，使用 Cpass:[++] 编写
+* +pyethereum+，使用 Python 编写
+* Mantis，使用 Scala 编写
+* Harmony，使用 Java 编写
+
+本节将重点介绍最常见的两个客户端：Parity 和 Geth。我们将展示如何使用每个客户端搭建节点，并探索它们的一些命令行选项和应用程序编程接口（API）。
+
+[[full_node_importance]]
+==== 我应该运行全节点吗？
+
+((("full node","Ethereum-based networks and", id="ix_03clients-asciidoc3", range="startofrange")))((("networks (Ethereum)","full nodes and", id="ix_03clients-asciidoc4", range="startofrange")))区块链的健康、韧性和抗审查能力依赖于大量独立运营且地理上分散的全节点。每个全节点都可以帮助其他新节点获取区块数据以启动运行，同时为节点运营者提供对所有交易和合约的权威、独立验证。
+
+不过，运行全节点会消耗硬件资源和带宽。截至 2021 年 3 月，根据客户端配置不同，全节点可能需要下载多达 300 GB 的数据并存储在本地硬盘上。随着新交易和新区块的加入，这种数据负担每天都会迅速增长。我们会在<<requirements>>中进一步讨论这一话题。
+
+在主网这样的实时网络上运行全节点并不是以太坊开发的必要条件。大多数开发工作都可以通过连接到较小的公共测试链（_testnet_ 节点）、使用像 Ganache 这样的本地私有区块链，或是使用 Infura 这类服务商提供的云端以太坊客户端来完成。
+
+你也可以运行远程客户端，它不会存储区块链的本地副本，也不会验证区块和交易。这类客户端具备钱包功能，并可以创建、广播交易。远程客户端可以用于连接现有网络，例如你自己的全节点、公共区块链、公共或许可制（权威证明）测试网，或本地私有区块链。实际使用中，你很可能会使用 MetaMask、Emerald Wallet、pass:[<span class="keep-together">MyEtherWallet</span>] 或 MyCrypto 这类远程客户端，以便在不同节点选项之间自由切换。
+
+((("remote clients","wallet compared to")))((("wallets","remote clients compared to")))“远程客户端”和“钱包”两个术语常被交替使用，尽管它们存在一些差异。通常，远程客户端除了具备钱包的交易功能之外，还会提供一个 API（例如 web3.js API）。
+
+((("light/lightweight client")))不要把以太坊中的远程钱包与_轻客户端_混淆（轻客户端类似比特币中的简化支付验证客户端）。轻客户端会验证区块头，并利用 Merkle 证明来验证交易被包含在区块链中及其效果，从而获得与全节点相近的安全级别。相反，以太坊远程客户端不会验证区块头或交易，它们完全信任某个全节点来访问区块链，因此失去了显著的安全性和匿名性保障。要缓解这些问题，可以使用自己运行的全节点。
+
+[[full_node_adv_disadv]]
+==== 全节点的优劣势
+
+((("full node","advantages/disadvantages")))选择运行全节点有助于你所连接网络的运行，但也会给自己带来一定的成本。下面我们来看看它的优缺点。
+
+*优势：*
+
+* 支持以太坊生态中各类网络的韧性和抗审查能力
+* 权威地验证所有交易
+* 可以在无需中介的情况下与公共区块链上的任意合约交互
+* 可以直接向公共区块链部署合约，无需中介
+* 可以离线查询（只读）区块链状态（账户、合约等）
+* 查询区块链时无需让第三方知道你正在读取的信息
+
+*劣势：*
+
+* 需要大量且持续增长的硬件与带宽资源
+* 初次启动时可能需要数天时间才能完成同步
+* 必须维护、升级并保持在线，才能持续同步(((range="endofrange", startref="ix_03clients-asciidoc4")))(((range="endofrange", startref="ix_03clients-asciidoc3")))
+
+[[pub_test_adv_disadv]]
+==== 公共测试网的优劣势
+
+((("networks (Ethereum)","public testnet advantages/disadvantages")))((("public testnets")))((("testnet","public")))无论是否运行全节点，你都可能希望运行一个公共测试网节点。我们来看看使用公共测试网的优缺点。
+
+*优势：*
+
+* 与主网相比，测试网节点需要同步和存储的数据少得多——约 75 GB，具体取决于网络
+* 测试网节点可以在更短时间内完成同步
+* 部署合约或发送交易只需要测试用的 ether，它没有任何价值，可从多个“faucet”免费获取
+* 测试网是拥有大量其他用户和合约的公共区块链，并且“实时”运行
+
+*劣势：*
+
+* 在测试网上无法使用“真实”货币；它运行在测试 ether 上。因此，你无法在其中针对真实对手测试安全性，因为没有任何实际利益相关
+* 公共区块链的一些方面无法在测试网中真实复现。例如，虽然在测试网上发送交易仍然需要支付交易费，但由于 gas 免费，费用并非重要考量。此外，测试网不会像公共主网那样偶尔出现网络拥堵
+
+[[localtest_adv_dis]]
+==== 本地区块链模拟的优劣势
+
+((("Ganache","advantages/disadvantages")))((("local blockchain simulation")))((("networks (Ethereum)","local blockchain simulation advantages/disadvantages")))((("private blockchain")))((("single-instance private blockchain")))在许多测试场景下，最佳选择是启动一个单实例私有区块链。Ganache（前称 +testrpc+）是最受欢迎的本地区块链模拟之一，你可以在没有其他参与者的情况下与之交互。它与公共测试网有许多共同优劣，但也存在一些差异。
+
+*优势：*
+
+* 无需同步，磁盘几乎不占空间；第一个区块由你自己挖出
+* 无需获取测试 ether；Ganache 会预先初始化持有测试 ether 的账户
+* 没有其他用户，只有你自己
+* 没有其他合约，除非你选择从已有的以太坊节点 fork，否则只会包含你启动后部署的合约
+
+*劣势：*
+
+* 没有其他用户意味着它的行为与公共区块链不同。没有竞争交易空间或交易排序
+* 除了你之外没有其他矿工，挖矿更加可预测；因此无法测试公共区块链上出现的某些情境
+* 如果你从现有以太坊节点 fork，就需要该节点是归档节点，才能访问那些否则可能被修剪掉的历史状态
+
+(((range="endofrange", startref="ix_03clients-asciidoc2")))(((range="endofrange", startref="ix_03clients-asciidoc1")))
+
+
+[[running_client]]
+=== 运行以太坊客户端
+
+((("clients, Ethereum","running", id="ix_03clients-asciidoc5", range="startofrange")))如果你有时间和资源，即使只是为了学习，也应该尝试运行一个全节点。本节将介绍如何下载、编译并运行 Parity 和 Geth，以太坊客户端。这需要你对操作系统的命令行界面有所了解。无论你将它们作为全节点、测试网节点，还是本地私有区块链的客户端，安装这些客户端都是值得的。
+
+[[requirements]]
+==== 全节点的硬件需求
+
+((("clients, Ethereum","full node hardware requirements")))((("full node","hardware requirements")))在开始之前，请确保你的电脑拥有足够资源运行以太坊全节点。你至少需要 300 GB 的磁盘空间来存储以太坊区块链的完整副本。如果还想在以太坊测试网上运行全节点，则至少需要额外的 75 GB。下载 375 GB 的区块链数据需要很长时间，因此建议使用高速互联网连接。
+
+同步以太坊区块链对输入/输出（I/O）需求极高。最好使用固态硬盘（SSD）。如果使用机械硬盘（HDD），至少需要 8 GB RAM 用作缓存，否则系统可能过慢而无法完成同步。
+
+*最低配置：*
+
+* 2 核以上 CPU
+* 至少 300 GB 可用存储空间
+* 使用 SSD 时至少 4 GB RAM，如使用 HDD 则需 8 GB 以上
+* 8 Mbit/sec 以上的下载带宽
+
+这些是同步以太坊区块链完整（但已修剪）副本的最低要求。
+
+截至撰写本文时，Parity 的代码库更节省资源，因此硬件受限时使用 Parity 通常效果更好。
+
+如果你希望在合理时间内完成同步，并存放本书讨论的所有开发工具、库、客户端和区块链，就需要一台更强大的电脑。
+
+*推荐配置：*
+
+* 4 核以上的高速 CPU
+* 16 GB 以上 RAM
+* 至少 500 GB 可用空间的高速 SSD
+* 25 Mbit/sec 以上的下载带宽
+
+很难预测区块链的体积会以多快速度增长、何时需要更多磁盘空间，因此建议在开始同步前先确认区块链的最新大小。
+
+[NOTE]
+====
+这里列出的磁盘需求假设你以默认设置运行节点，即区块链会对旧状态数据进行“修剪”。如果改为运行保留全部状态的“归档”节点，则可能需要超过 1 TB 的磁盘空间。
+====
+
+以下链接提供区块链大小的最新估算：
+
+* https://bitinfocharts.com/ethereum/[Ethereum]
+
+* https://bitinfocharts.com/ethereum%20classic/[Ethereum Classic]
+
+[[sw_reqs]]
+==== 构建并运行客户端（节点）的软件需求
+
+((("clients, Ethereum","software requirements for building/running", id="ix_03clients-asciidoc6", range="startofrange")))本节介绍 Parity 和 Geth 客户端软件。我们假设你使用的是类 Unix 的命令行环境。示例展示的是在 Ubuntu GNU/Linux 操作系统、bash shell（命令行执行环境）中运行的命令及输出。
+
+通常，每条区块链都会有自己版本的 Geth，而 Parity 则通过同一个客户端下载支持多条基于以太坊的区块链（Ethereum、Ethereum Classic、pass:[<span class="keep-together">Ellaism</span>]、Expanse、Musicoin）。
+
+[TIP]
+=====
+((("$ symbol")))((("command-line interface")))((("shell commands")))((("terminal applications")))在本章的许多示例中，我们会使用操作系统的命令行界面（也称为“shell”），通过“终端”应用来访问。shell 会显示一个提示符；你输入命令后，shell 会回应一些文本并再次显示提示符。提示符在你的系统上可能看起来不同，但在以下示例中，我们用 +$+ 符号表示。在示例里，当你看到 +$+ 符号后的文本时，不要输入 +$+，而是输入紧随其后的命令（加粗显示），然后按 Enter 执行。示例中每个命令下方的行都是操作系统对该命令的输出。当你看到下一个 +$+ 前缀时，就表示这是新命令，你需要重复这一过程。
+=====
+
+在开始之前，你可能需要安装一些软件。如果你目前使用的这台电脑从未进行过软件开发，可能需要安装一些基础工具。在接下来的示例中，你需要安装源码管理系统 +git+、Go 编程语言及其标准库 +golang+，以及系统编程语言 Rust。
+
+((("git")))可以按照 https://git-scm.com[] 提供的说明安装 Git。
+
+((("Go", seealso="Geth (Go-Ethereum)")))可以按照 https://golang.org[] 上的说明安装 Go；如果使用 Ubuntu，可以参考 https://github.com/golang/go/wiki/Ubuntu[]。
+
+[NOTE]
+=====
+((("Geth (Go-Ethereum)")))Geth 的需求因版本而异，但如果使用 Go 1.13 或更高版本，大多数 Geth 版本都能编译。当然，应始终参考所选 Geth 版本的文档。
+
+你操作系统中预装或通过包管理器提供的 +golang+ 版本可能明显低于 1.13。如果遇到这种情况，请移除旧版本，并从 https://golang.org/[] 安装最新版本。
+=====
+
+((("Rust")))可以按照 https://www.rustup.rs/[] 上的说明安装 Rust。
+
+[NOTE]
+=====
+Parity 需要 Rust 1.27 或更高版本。
+=====
+
+((("Parity","libraries for")))Parity 还需要安装一些软件库，如 OpenSSL 和 +libudev+。在 Ubuntu 或 Debian GNU/Linux 兼容系统上，可以使用以下命令安装：
+
+++++
+<pre data-type="programlisting">
+$ <strong>sudo apt-get install openssl libssl-dev libudev-dev cmake clang</strong>
+</pre>
+++++
+
+在其他操作系统上，请使用你的操作系统的包管理器，或按照 https://github.com/paritytech/parity/wiki/Setup[Wiki 说明]安装所需库。
+
+现在你已经安装好了 +git+、+golang+、Rust 以及必备库，接下来开始动手吧！
+
+[[parity]]
+==== Parity
+
+((("clients, Ethereum","Parity and")))((("Parity","basics")))Parity 是一个全节点以太坊客户端和 DApp 浏览器的实现。它使用系统编程语言 Rust 从零开始构建，目标是打造模块化、安全、可扩展的以太坊客户端。Parity 由英国公司 Parity Tech 开发，并以 GPLv3 自由软件许可证发布。
+
+[NOTE]
+=====
+声明：本书作者之一 Gavin Wood 博士是 Parity Tech 的创始人，并编写了 Parity 客户端的大部分代码。Parity 约占以太坊客户端装机量的 25%。
+=====
+
+安装 Parity 时，你可以使用 Rust 包管理器 +cargo+，或从 GitHub 下载源代码。包管理器同样会下载源代码，因此这两种方式差别不大。接下来的部分将展示如何自行下载并编译 Parity。
+
+[[install_parity]]
+===== 安装 Parity
+
+((("Parity","installing")))https://wiki.parity.io/Setup[Parity Wiki] 提供了在不同环境和容器中构建 Parity 的说明。我们将演示如何从源码构建 Parity。这假设你已经使用 +rustup+ 安装了 Rust（见<<sw_reqs>>）。
+
+首先，从 GitHub 获取源代码：
+
+++++
+<pre data-type="programlisting">
+$ <strong>git clone https://github.com/paritytech/parity</strong>
+</pre>
+++++
+
+然后切换到 _parity_ 目录，并使用 +cargo+ 构建可执行文件：
+
+++++
+<pre data-type="programlisting">
+$ <strong>cd parity</strong>
+$ <strong>cargo install --path .</strong>
+</pre>
+++++
+
+如果一切顺利，你会看到类似如下的输出：
+
+++++
+<pre data-type="programlisting">
+$ <strong>cargo install --path .</strong>
+Installing parity-ethereum v2.7.0 (/root/parity)
+Updating crates.io index
+Updating git repository `https://github.com/paritytech/rust-ctrlc.git`
+Updating git repository `https://github.com/paritytech/app-dirs-rs`   Updating git repository
+
+ [...]
+
+Compiling parity-ethereum v2.7.0 (/root/parity)
+Finished release [optimized] target(s) in 10m 16s
+Installing /root/.cargo/bin/parity
+Installed package `parity-ethereum v2.7.0 (/root/parity)` (executable `parity`)
+$
+</pre>
+++++
+
+尝试使用 +--version+ 选项运行 +parity+，确认它已安装：
+
+++++
+<pre data-type="programlisting">
+$ <strong>parity --version</strong>
+Parity Ethereum Client.
+  version Parity-Ethereum/v2.7.0-unstable-b69a33b3a-20200124/x86_64-unknown-linux-gnu/rustc1.40.0
+Copyright 2015-2020 Parity Technologies (UK) Ltd.
+License GPLv3+: GNU GPL version 3 or later <ulink url="http://gnu.org/licenses/gpl.html">http://gnu.org/licenses/gpl.html</ulink>.
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+
+By Wood/Paronyan/Kotewicz/Drwięga/Volf/Greeff
+   Habermeier/Czaban/Gotchac/Redman/Nikolsky
+   Schoedon/Tang/Adolfsson/Silva/Palm/Hirsz et al.
+$
+</pre>
+++++
+
+太好了！安装完成后，你就可以开始同步区块链，并尝试一些基本的命令行选项。
+
+[[go_ethereum_geth]]
+==== Go-Ethereum（Geth）
+
+((("clients, Ethereum","Geth and", id="ix_03clients-asciidoc7", range="startofrange")))((("Geth (Go-Ethereum)","basics", id="ix_03clients-asciidoc8", range="startofrange")))Geth 是以太坊基金会积极维护的 Go 语言实现，因此被视为“官方”的以太坊客户端实现。通常，每条基于以太坊的区块链都会提供自己的 Geth 实现。如果你运行 Geth，请务必通过以下代码仓库之一获取适合目标区块链的版本：
+
+* https://github.com/ethereum/go-ethereum[Ethereum]（或 https://geth.ethereum.org/）
+
+* https://github.com/etclabscore/go-ethereum[Ethereum Classic]
+
+* https://github.com/ellaism/go-ellaism[Ellaism]
+
+* https://github.com/expanse-org/go-expanse[Expanse]
+
+* https://github.com/Musicoin/go-musicoin[Musicoin]
+
+* https://github.com/ubiq/go-ubiq[Ubiq]
+
+[NOTE]
+=====
+你也可以跳过这些步骤，直接安装适用于目标平台的预编译二进制文件。这些预编译版本更易于安装，可以在上述任一仓库的“releases”栏目中找到。不过，亲自下载并编译软件会让你学到更多。
+=====
+
+[[cloning_repo]]
+===== 克隆代码仓库
+
+((("Geth (Go-Ethereum)","cloning Git repo for")))第一步是克隆 Git 仓库，从而获得源代码副本。
+
+在主目录或用于开发的任意目录下，可以使用以下 +git+ 命令创建本地副本：
+
+++++
+<pre data-type="programlisting">
+$ <strong>git clone &lt;Repository Link&gt;</strong>
+</pre>
+++++
+
+仓库复制到本地时，你将看到如下的进度信息：
+
+[[cloning_status]]
+----
+Cloning into 'go-ethereum'...
+remote: Enumerating objects: 86915, done.
+remote: Total 86915 (delta 0), reused 0 (delta 0), pack-reused 86915
+Receiving objects: 100% (86915/86915), 134.73 MiB | 29.30 MiB/s, done.
+Resolving deltas: 100% (57590/57590), done.
+----
+
+太好了！现在你已经拥有 Geth 的本地副本，可以为自己的平台编译可执行文件。
+
+[[build_geth_src]]
+===== 从源码构建 Geth
+
+((("Geth (Go-Ethereum)","building from source code")))要构建 Geth，请切换到下载源代码的目录，并使用 +make+ 命令：
+
+++++
+<pre data-type="programlisting">
+$ <strong>cd go-ethereum</strong>
+$ <strong>make geth</strong>
+</pre>
+++++
+
+如果一切顺利，你会看到 Go 编译器逐个构建组件，直到生成 +geth+ 可执行文件：
+
+[[making_geth_status]]
+----
+build/env.sh go run build/ci.go install ./cmd/geth
+>>> /usr/local/go/bin/go install -ldflags -X main.gitCommit=58a1e13e6dd7f52a1d...
+github.com/ethereum/go-ethereum/common/hexutil
+github.com/ethereum/go-ethereum/common/math
+github.com/ethereum/go-ethereum/crypto/sha3
+github.com/ethereum/go-ethereum/rlp
+github.com/ethereum/go-ethereum/crypto/secp256k1
+github.com/ethereum/go-ethereum/common
+[...]
+github.com/ethereum/go-ethereum/cmd/utils
+github.com/ethereum/go-ethereum/cmd/geth
+Done building.
+Run "build/bin/geth" to launch geth.
+$
+----
+
+让我们在不真正启动的情况下确认 +geth+ 是否可以运行：
+
+++++
+<pre data-type="programlisting">
+$ <strong>./build/bin/geth version</strong>
+
+Geth
+Version: 1.9.11-unstable
+Git Commit: 0b284f6c6cfc6df452ca23f9454ee16a6330cb8e
+Git Commit Date: 20200123
+Architecture: amd64
+Protocol Versions: [64 63]
+Go Version: go1.13.4
+Operating System: linux
+[...]
+</pre>
+++++
+
+你的 +geth version+ 命令输出可能略有不同，但应与此处显示的版本报告大体一致。
+
+接下来的章节将解释首次同步以太坊区块链时面临的挑战(((range="endofrange", startref="ix_03clients-asciidoc6"))).(((range="endofrange", startref="ix_03clients-asciidoc5")))
+
+
+[[first_sync]]
+=== 基于以太坊的区块链的首次同步
+
+((("blockchain","first synchronization of", id="ix_03clients-asciidoc9", range="startofrange")))((("clients, Ethereum","first synchronization of Ethereum-based blockchains", id="ix_03clients-asciidoc10", range="startofrange")))((("first synchronization","of Ethereum-based blockchains", id="ix_03clients-asciidoc11", range="startofrange")))传统上，在同步以太坊区块链时，客户端会自创世区块开始下载并验证每个区块和每笔交易。
+
+虽然可以通过这种方式完全同步区块链，但过程耗时极长、资源需求也很高（需要更多 RAM，如果没有高速存储，所需时间会更长）。
+
+许多基于以太坊的区块链在 2016 年底遭受了拒绝服务攻击。受到影响的区块链在执行完全同步时往往会变得很慢。
+
+以以太坊为例，新客户端会快速推进，直到到达区块 2,283,397。该区块于 2016 年 9 月 18 日被挖出，标志着 DoS 攻击的开始。从此区块到区块 2,700,031（2016 年 11 月 26 日），交易验证会变得异常缓慢、占用大量内存和 I/O 资源，导致每个区块的验证时间超过 1 分钟。以太坊通过一系列硬分叉升级修复了 DoS 攻击所利用的漏洞，同时清理掉垃圾交易创建的大约 2000 万个空账户。
+
+如果你执行的是完全验证，同步在遇到这些受 DoS 影响的区块时会明显放缓，并可能需要数天甚至更长时间才能完成验证。
+
+((("fast synchronization")))幸运的是，大多数以太坊客户端如今默认执行“快速”同步，即在同步到区块链顶端之前跳过对交易的完整验证，然后再恢复完全验证。
+
+Geth 在以太坊上默认执行快速同步。对于其他你选择的以太坊网络，请参考相应的具体说明。
+
+Parity 也默认执行快速同步。
+
+[NOTE]
+=====
+只有在区块数据库为空的情况下，Geth 才能以快速模式运行。如果你已经在未启用快速模式的情况下开始同步，Geth 无法中途切换。删除区块链数据目录并从头开始快速同步，比继续进行完全验证同步更快。删除区块链数据时务必小心，不要误删钱包！
+=====
+
+==== 运行 Geth 或 Parity
+
+((("first synchronization","Geth or Parity for")))((("Geth (Go-Ethereum)","for first synchronization")))((("Parity","for first synchronization")))现在你了解了“首次同步”的挑战，就可以启动以太坊客户端并同步区块链了。对于 Geth 和 Parity，你都可以使用 +--help+ 选项查看全部配置参数。默认设置通常已经合理，适用于大多数场景。根据自身需求选择性调整可选参数，然后启动 Geth 或 Parity 同步链。接下来，就是等待……
+
+[TIP]
+====
+同步以太坊区块链的时间从半天（在拥有大量 RAM 的高速系统上）到数天（在较慢的系统上）不等。
+====
+
+[[json_rpc]]
+==== JSON-RPC 接口
+
+((("clients, Ethereum","and JSON-RPC API", id="ix_03clients-asciidoc12", range="startofrange")))((("first synchronization","and JSON-RPC API", id="ix_03clients-asciidoc13", range="startofrange")))((("JSON-RPC API", id="ix_03clients-asciidoc14", range="startofrange")))以太坊客户端提供一个应用程序编程接口和一组远程过程调用（RPC）命令，这些命令使用 JavaScript Object Notation（JSON）编码。通常称为_JSON-RPC API_。本质上，JSON-RPC API 让我们能够编写程序，将以太坊客户端当作通往以太坊网络和区块链的_网关_。
+
+通常，RPC 接口作为 HTTP 服务运行在端口 8545 上。出于安全考虑，默认情况下它只接受来自 localhost（本机 IP 地址 127.0.0.1）的连接。
+
+...
+++++
+
+[[lw_eth_clients]]
+=== 远程以太坊客户端
+
+((("clients, Ethereum","remote", id="ix_03clients-asciidoc15", range="startofrange")))((("remote clients", id="ix_03clients-asciidoc16", range="startofrange")))远程客户端提供全节点功能的一个子集。它们不会存储完整的以太坊区块链，因此设置速度更快，也几乎不需要数据存储。
+
+[role="pagebreak-before"]
+这些客户端通常具备以下一项或多项能力：
+
+* 在钱包中管理私钥和以太坊地址
+* 创建、签名并广播交易
+* 使用数据负载与智能合约交互
+* 浏览并与 DApp 互动
+* 提供指向区块浏览器等外部服务的链接
+* 将 web3 实例以 JavaScript 对象注入浏览器
+* 使用其他客户端注入到浏览器中的 web3 实例
+* 访问本地或远程以太坊节点上的 RPC 服务
+
+有些远程客户端（例如移动端钱包）只提供基本的钱包功能。另一些远程客户端则是功能完整的 DApp 浏览器。远程客户端通常无需同步区块链本地副本，就能通过连接其他地方运行的全节点（例如你自己的机器、网页服务器或第三方的服务器）提供部分全节点功能。
+
+下面我们来了解几款热门远程客户端及其功能。
+
+[[mobile_wallets]]
+==== 移动（智能手机）钱包
+
+((("mobile (smartphone) wallets")))((("remote clients","mobile wallets")))((("wallets","mobile")))所有移动钱包都是远程客户端，因为智能手机的资源不足以运行完整的以太坊客户端。以太坊的轻客户端仍在开发中，尚未普遍使用。在 Parity 中，轻客户端被标记为“实验性”，可以通过运行 +parity+ 并添加 +--light+ 选项来启用。
+
+常见的移动钱包包括（仅列举示例，并不代表对这些钱包的安全性或功能性作出推荐或评价）：
+
+https://jaxx.io[Jaxx]:: ((("Jaxx","mobile version")))((("wallets","Jaxx")))基于 BIP-39 助记词的多币种移动钱包，支持 Bitcoin、Litecoin、Ethereum、Ethereum Classic、ZCash、多种 ERC20 代币以及其他货币。Jaxx 可用于 Android 和 iOS，也提供浏览器插件钱包和多种操作系统的桌面钱包。
+
+https://status.im[Status]:: ((("Status (mobile wallet)")))一款移动钱包和 DApp 浏览器，支持多种代币及常用 DApp。适用于 iOS 和 Android。
+
+https://trustwalletapp.com/[Trust Wallet]:: ((("Trust Wallet")))((("wallets","Trust")))一款移动多币种钱包，支持 Ethereum、Ethereum Classic 以及 ERC20、ERC223 代币。Trust Wallet 提供 iOS 和 Android 版本。
+
+https://www.cipherbrowser.com[Cipher Browser]:: ((("Cipher Browser")))全功能的以太坊移动 DApp 浏览器和钱包，可与以太坊应用和代币集成。适用于 iOS 和 Android。
+
+[[browser_wallets]]
+==== 浏览器钱包
+
+((("browser wallets")))((("remote clients","browser wallets")))((("wallets","browser wallets")))多种钱包和 DApp 浏览器以 Chrome、Firefox 等浏览器的插件或扩展形式提供。它们是运行在浏览器中的远程客户端。
+
+比较流行的有 MetaMask、Jaxx、MyEtherWallet 和 MyCrypto。
+
+[[MetaMask]]
+===== MetaMask
+
+https://metamask.io/[MetaMask] ((("MetaMask","as browser wallet")))已在<<intro_chapter>>中介绍，是一款功能多样的浏览器钱包、RPC 客户端和基础合约浏览器。它可在 Chrome、Firefox、Opera 和 Brave 浏览器上使用。
+
+与其他浏览器钱包不同，MetaMask 会在浏览器的 JavaScript 上下文中注入 web3 实例，充当 RPC 客户端，连接多种以太坊区块链（主网、Ropsten 测试网、Kovan 测试网、本地 RPC 节点等）。能够注入 web3 实例并作为外部 RPC 服务的网关，使 MetaMask 成为开发者和用户的强大工具。例如，它可以与 MyEtherWallet 或 MyCrypto 组合使用，为这些工具提供 web3 Provider 和 RPC 网关。
+
+[[Jaxx]]
+===== Jaxx
+
+https://jaxx.io[Jaxx] ((("Jaxx","desktop version")))((("wallets","Jaxx")))前文作为移动钱包介绍过，同时也提供 Chrome 和 Firefox 扩展以及桌面钱包版本。
+
+[[MEW]]
+===== MyEtherWallet (MEW)
+
+https://www.myetherwallet.com/[MyEtherWallet] ((("MyEtherWallet (MEW)")))((("wallets","MyEtherWallet")))是一款基于浏览器的 JavaScript 远程客户端，提供以下功能：
+
+* 与 Trezor、Ledger 等热门硬件钱包对接
+* 提供 web3 接口，可连接由其他客户端（如 MetaMask）注入的 web3 实例
+* 作为 RPC 客户端连接以太坊全节点
+* 基本的智能合约交互界面，只需提供合约地址和应用二进制接口（ABI）即可
+* 提供移动应用 MEWConnect，可让兼容的 Android 或 iOS 设备像硬件钱包一样存储资金
+* 在 JavaScript 中运行的软件钱包
+
+[WARNING]
+====
+访问 MyEtherWallet 及其他基于浏览器的 JavaScript 钱包时务必谨慎，因为它们经常成为钓鱼攻击目标。请始终使用收藏夹中的书签，而非搜索引擎或外部链接，以确保访问正确的网址。
+====
+
+[[MyCrypto]]
+===== MyCrypto
+
+((("MyCrypto (wallet)")))((("wallets","MyCrypto")))2018 年初，((("MyEtherWallet (MEW)")))((("wallets","MyEtherWallet")))MyEtherWallet 项目分裂成由两个独立开发团队维护的竞品实现，这是开源开发中常见的“分叉”。这两个项目分别是沿用原品牌的 MyEtherWallet，以及 https://mycrypto.com/[MyCrypto]。MyCrypto 的功能几乎与 MyEtherWallet 完全一致，但它使用 Parity Signer 移动应用与手机连接，而不是 MEWConnect。Parity Signer 同样在手机上存储密钥，并以类似硬件钱包的方式与 MyCrypto 交互。
+
+[[Mist]]
+===== Mist（已弃用）
+
+https://github.com/ethereum/mist[Mist] ((("Mist (browser-based wallet)")))((("wallets","Mist")))是以太坊基金会构建的第一款支持以太坊的浏览器。它内置的浏览器钱包是 ERC20 代币标准的首次实现（ERC20 作者 Fabian Vogelsteller 也是 Mist 的主要开发者）。Mist 也是首个引入驼峰式校验和（EIP-55）的钱包。自 2019 年 3 月起，Mist 已被弃用，不应再使用。
+
+=== 小结
+
+本章我们探索了以太坊客户端。你已经下载、安装并同步了客户端，成为以太坊网络中的一员，通过在自己的电脑上复制区块链，为系统的健康与稳定作出贡献。(((range="endofrange", startref="ix_03clients-asciidoc0")))


### PR DESCRIPTION
## Summary
- add a full Chinese translation of the Ethereum clients chapter, covering network types, full node considerations, and node setup guidance
- document Parity and Geth installation workflows along with hardware/software prerequisites in Chinese
- translate the remote client overview, including mobile and browser wallet descriptions and safety notes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dc010c148c83268cf6913fa01f75ce